### PR TITLE
#2 ドメイン型と設定土台を追加

### DIFF
--- a/ai/tasks/readme.md
+++ b/ai/tasks/readme.md
@@ -6,3 +6,5 @@
 - 2026-04-03: `.codex/skills/implement-from-test` を追加
 - `implement-from-test` は failing test を満たす最小実装に限定する
 - 2026-04-06: issue 全体の受け入れ条件は `create-feature-test`、subtask の red test は `create-subtask-test` に分離した
+- 2026-04-06 issue #2: `internal/config` は `LoadFromLookup` を公開し、テストから環境変数依存を切り離す
+- 2026-04-06 issue #2: `PDFTK_PATH` は未指定時に `pdftk` を使うデフォルトで扱い、環境差分を最小化する

--- a/ai/tasks/todo.md
+++ b/ai/tasks/todo.md
@@ -53,3 +53,26 @@
 - `internal/app.Runner` を追加し、各 Lambda handler が concrete type に依存せずテスト可能な形にした
 - `cmd/*/main_test.go` で各 Lambda の開始・終了・失敗ログを検証し、`request_id` と `level` がエントリ全体で保たれることを確認した
 - `GOCACHE=$(pwd)/.cache/go-build GOMODCACHE=$(pwd)/.cache/gomod go test ./...` は成功した
+
+## 2026-04-06 issue #2 実装計画
+
+- [x] issue #2 の作業範囲を `Config` と Notion ドメイン型の最小整備に限定する
+- [x] `internal/config` 相当の設定読み込み・必須値検証を先に固める
+- [x] Transactions / Customers / Invoices / Cashflow の内部名に沿った最小 struct を追加する
+- [x] JSON マッピングと必須項目欠落時のエラー動作をテストで固定する
+- [x] issue 全体の feature-level integration test と review を実行する
+
+### Subtasks
+
+- [x] `config` - ENV, DB IDs, S3, SendGrid, pdftk パスを持つ `Config` を追加し、必須値欠落をエラーにする
+- [x] `notion-model` - Transactions / Customers / Invoices / Cashflow の最小 struct を追加し、内部名ベースの JSON マッピングを定義する
+- [x] `tests` - 有効値の JSON 逆変換と、必須項目欠落時の失敗を確認する issue-level テストを追加する
+
+### Review
+
+- issue #2 は後続モジュールが共通利用する土台の整備であり、業務ロジックはまだ入れない
+- `internal/config.Config` と `LoadFromLookup` を追加し、必須環境変数不足を `MissingEnvironmentError` で返すようにした
+- `PDFTK_PATH` は未設定時に `pdftk` を使うデフォルトにし、HLD のコマンド前提を保った
+- `internal/domain` に 4 DB 用の最小 Notion record struct と property struct を追加し、内部名 tag を固定した
+- `internal/acceptance/issue2_feature_test.go` と unit test により JSON round-trip と設定読み込みを固定した
+- `cd /home/user/workspaces/notion-invoice-with-lambda-worktrees/issue-2 && GOCACHE=/tmp/notion-invoice-issue2-go-build GOMODCACHE=/tmp/notion-invoice-issue2-gomod go test ./...` は成功した

--- a/internal/acceptance/issue2_feature_test.go
+++ b/internal/acceptance/issue2_feature_test.go
@@ -1,0 +1,96 @@
+package acceptance_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/config"
+	"github.com/irukasano/notion-invoice-with-lambda/internal/domain"
+)
+
+func TestIssue2Feature_ConfigAndNotionRecords(t *testing.T) {
+	cfg, err := config.LoadFromLookup(func(key string) (string, bool) {
+		values := map[string]string{
+			"ENV":                    "stg",
+			"S3_BUCKET":              "invoice-pdf-stg",
+			"NOTION_DB_TRANSACTIONS": "tx-db",
+			"NOTION_DB_CUSTOMERS":    "customers-db",
+			"NOTION_DB_INVOICES":     "invoices-db",
+			"NOTION_DB_CASHFLOW":     "cashflow-db",
+			"NOTION_TOKEN":           "secret",
+			"SENDGRID_BASE_URL":      "https://api.sendgrid.test",
+			"SENDGRID_API_KEY":       "sendgrid-key",
+			"SENDGRID_FROM_EMAIL":    "billing@example.com",
+			"SENDGRID_FROM_NAME":     "Billing Bot",
+		}
+		value, ok := values[key]
+		return value, ok
+	})
+	if err != nil {
+		t.Fatalf("LoadFromLookup returned error: %v", err)
+	}
+	if cfg.PDFTKPath != "pdftk" {
+		t.Fatalf("default PDFTKPath mismatch: got %q", cfg.PDFTKPath)
+	}
+
+	records := []any{
+		domain.TransactionRecord{
+			Properties: domain.TransactionProperties{
+				Title: domain.TitleProperty{
+					Type: "title",
+					Title: []domain.RichTextObject{{
+						Type:      "text",
+						PlainText: "12月保守費",
+						Text: &domain.TextContent{
+							Content: "12月保守費",
+						},
+					}},
+				},
+			},
+		},
+		domain.CustomerRecord{
+			Properties: domain.CustomerProperties{
+				Title: domain.TitleProperty{
+					Type: "title",
+					Title: []domain.RichTextObject{{
+						Type:      "text",
+						PlainText: "株式会社サンプル",
+						Text: &domain.TextContent{
+							Content: "株式会社サンプル",
+						},
+					}},
+				},
+			},
+		},
+		domain.InvoiceRecord{
+			Properties: domain.InvoiceProperties{
+				Title: domain.TitleProperty{
+					Type: "title",
+					Title: []domain.RichTextObject{{
+						Type:      "text",
+						PlainText: "S-AB202512-01",
+						Text: &domain.TextContent{
+							Content: "S-AB202512-01",
+						},
+					}},
+				},
+			},
+		},
+		domain.CashflowRecord{
+			Properties: domain.CashflowProperties{
+				Date: domain.DateProperty{
+					Type: "date",
+					Date: &domain.DateValue{
+						Start: "2025-12-31",
+					},
+				},
+			},
+		},
+	}
+
+	for _, record := range records {
+		if _, err := json.Marshal(record); err != nil {
+			t.Fatalf("json.Marshal returned error: %v", err)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const defaultPDFTKPath = "pdftk"
+
+type Config struct {
+	Env                  string
+	S3Bucket             string
+	NotionDBTransactions string
+	NotionDBCustomers    string
+	NotionDBInvoices     string
+	NotionDBCashflow     string
+	NotionToken          string
+	SendGridBaseURL      string
+	SendGridAPIKey       string
+	SendGridFromEmail    string
+	SendGridFromName     string
+	PDFTKPath            string
+}
+
+type MissingEnvironmentError struct {
+	Keys []string
+}
+
+func (e MissingEnvironmentError) Error() string {
+	return fmt.Sprintf(
+		"missing required environment variables: %s",
+		strings.Join(e.Keys, ", "),
+	)
+}
+
+func Load() (Config, error) {
+	return LoadFromLookup(os.LookupEnv)
+}
+
+func LoadFromLookup(lookup func(string) (string, bool)) (Config, error) {
+	cfg := Config{
+		Env:                  lookupRequired(lookup, "ENV"),
+		S3Bucket:             lookupRequired(lookup, "S3_BUCKET"),
+		NotionDBTransactions: lookupRequired(lookup, "NOTION_DB_TRANSACTIONS"),
+		NotionDBCustomers:    lookupRequired(lookup, "NOTION_DB_CUSTOMERS"),
+		NotionDBInvoices:     lookupRequired(lookup, "NOTION_DB_INVOICES"),
+		NotionDBCashflow:     lookupRequired(lookup, "NOTION_DB_CASHFLOW"),
+		NotionToken:          lookupRequired(lookup, "NOTION_TOKEN"),
+		SendGridBaseURL:      lookupRequired(lookup, "SENDGRID_BASE_URL"),
+		SendGridAPIKey:       lookupRequired(lookup, "SENDGRID_API_KEY"),
+		SendGridFromEmail:    lookupRequired(lookup, "SENDGRID_FROM_EMAIL"),
+		SendGridFromName:     lookupRequired(lookup, "SENDGRID_FROM_NAME"),
+		PDFTKPath:            lookupOptional(lookup, "PDFTK_PATH", defaultPDFTKPath),
+	}
+
+	missing := cfg.missingRequired()
+	if len(missing) > 0 {
+		return Config{}, MissingEnvironmentError{Keys: missing}
+	}
+
+	return cfg, nil
+}
+
+func lookupRequired(lookup func(string) (string, bool), key string) string {
+	value, _ := lookup(key)
+	return value
+}
+
+func lookupOptional(lookup func(string) (string, bool), key, fallback string) string {
+	value, ok := lookup(key)
+	if !ok || value == "" {
+		return fallback
+	}
+	return value
+}
+
+func (c Config) missingRequired() []string {
+	missing := make([]string, 0, 11)
+	required := map[string]string{
+		"ENV":                    c.Env,
+		"NOTION_DB_CASHFLOW":     c.NotionDBCashflow,
+		"NOTION_DB_CUSTOMERS":    c.NotionDBCustomers,
+		"NOTION_DB_INVOICES":     c.NotionDBInvoices,
+		"NOTION_DB_TRANSACTIONS": c.NotionDBTransactions,
+		"NOTION_TOKEN":           c.NotionToken,
+		"S3_BUCKET":              c.S3Bucket,
+		"SENDGRID_API_KEY":       c.SendGridAPIKey,
+		"SENDGRID_BASE_URL":      c.SendGridBaseURL,
+		"SENDGRID_FROM_EMAIL":    c.SendGridFromEmail,
+		"SENDGRID_FROM_NAME":     c.SendGridFromName,
+	}
+
+	for key, value := range required {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
+	}
+	sort.Strings(missing)
+
+	return missing
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"errors"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+func TestLoadFromLookupReturnsConfig(t *testing.T) {
+	cfg, err := LoadFromLookup(lookupFromMap(map[string]string{
+		"ENV":                    "stg",
+		"S3_BUCKET":              "invoice-pdf-stg",
+		"NOTION_DB_TRANSACTIONS": "tx-db",
+		"NOTION_DB_CUSTOMERS":    "customers-db",
+		"NOTION_DB_INVOICES":     "invoices-db",
+		"NOTION_DB_CASHFLOW":     "cashflow-db",
+		"NOTION_TOKEN":           "secret",
+		"SENDGRID_BASE_URL":      "https://api.sendgrid.test",
+		"SENDGRID_API_KEY":       "sendgrid-key",
+		"SENDGRID_FROM_EMAIL":    "billing@example.com",
+		"SENDGRID_FROM_NAME":     "Billing Bot",
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromLookup returned error: %v", err)
+	}
+
+	want := Config{
+		Env:                  "stg",
+		S3Bucket:             "invoice-pdf-stg",
+		NotionDBTransactions: "tx-db",
+		NotionDBCustomers:    "customers-db",
+		NotionDBInvoices:     "invoices-db",
+		NotionDBCashflow:     "cashflow-db",
+		NotionToken:          "secret",
+		SendGridBaseURL:      "https://api.sendgrid.test",
+		SendGridAPIKey:       "sendgrid-key",
+		SendGridFromEmail:    "billing@example.com",
+		SendGridFromName:     "Billing Bot",
+		PDFTKPath:            defaultPDFTKPath,
+	}
+	if !reflect.DeepEqual(cfg, want) {
+		t.Fatalf("config mismatch: got %#v want %#v", cfg, want)
+	}
+}
+
+func TestLoadFromLookupUsesPDFTKOverride(t *testing.T) {
+	cfg, err := LoadFromLookup(lookupFromMap(map[string]string{
+		"ENV":                    "prod",
+		"S3_BUCKET":              "invoice-pdf-prod",
+		"NOTION_DB_TRANSACTIONS": "tx-db",
+		"NOTION_DB_CUSTOMERS":    "customers-db",
+		"NOTION_DB_INVOICES":     "invoices-db",
+		"NOTION_DB_CASHFLOW":     "cashflow-db",
+		"NOTION_TOKEN":           "secret",
+		"SENDGRID_BASE_URL":      "https://api.sendgrid.test",
+		"SENDGRID_API_KEY":       "sendgrid-key",
+		"SENDGRID_FROM_EMAIL":    "billing@example.com",
+		"SENDGRID_FROM_NAME":     "Billing Bot",
+		"PDFTK_PATH":             "/opt/bin/pdftk",
+	}))
+	if err != nil {
+		t.Fatalf("LoadFromLookup returned error: %v", err)
+	}
+	if cfg.PDFTKPath != "/opt/bin/pdftk" {
+		t.Fatalf("PDFTKPath mismatch: got %q", cfg.PDFTKPath)
+	}
+}
+
+func TestLoadFromLookupReturnsMissingEnvironmentError(t *testing.T) {
+	_, err := LoadFromLookup(lookupFromMap(map[string]string{
+		"ENV":                    "stg",
+		"S3_BUCKET":              "invoice-pdf-stg",
+		"NOTION_DB_TRANSACTIONS": "tx-db",
+		"SENDGRID_BASE_URL":      "https://api.sendgrid.test",
+		"SENDGRID_FROM_NAME":     "Billing Bot",
+	}))
+	if err == nil {
+		t.Fatal("LoadFromLookup error = nil")
+	}
+
+	var missingErr MissingEnvironmentError
+	if !errors.As(err, &missingErr) {
+		t.Fatalf("error type mismatch: got %T", err)
+	}
+
+	want := []string{
+		"NOTION_DB_CASHFLOW",
+		"NOTION_DB_CUSTOMERS",
+		"NOTION_DB_INVOICES",
+		"NOTION_TOKEN",
+		"SENDGRID_API_KEY",
+		"SENDGRID_FROM_EMAIL",
+	}
+	if !slices.Equal(missingErr.Keys, want) {
+		t.Fatalf("missing keys mismatch: got %v want %v", missingErr.Keys, want)
+	}
+}
+
+func lookupFromMap(values map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		value, ok := values[key]
+		return value, ok
+	}
+}

--- a/internal/domain/notion.go
+++ b/internal/domain/notion.go
@@ -1,0 +1,177 @@
+package domain
+
+type TransactionRecord struct {
+	ID         string                `json:"id,omitempty"`
+	Properties TransactionProperties `json:"properties"`
+}
+
+type TransactionProperties struct {
+	Title           TitleProperty    `json:"title"`
+	Customer        RelationProperty `json:"customer,omitempty"`
+	CashDate        DateProperty     `json:"cash_date,omitempty"`
+	Amount          NumberProperty   `json:"amount,omitempty"`
+	Category        SelectProperty   `json:"category,omitempty"`
+	IncludeCashflow CheckboxProperty `json:"include_cashflow"`
+	Description     RichTextProperty `json:"description,omitempty"`
+	Qty             NumberProperty   `json:"qty,omitempty"`
+	UnitPrice       NumberProperty   `json:"unit_price,omitempty"`
+	LineTotal       FormulaProperty  `json:"line_total,omitempty"`
+	BillingDate     DateProperty     `json:"billing_date,omitempty"`
+	PaymentDue      DateProperty     `json:"payment_due,omitempty"`
+	Invoice         RelationProperty `json:"invoice,omitempty"`
+	Status          StatusProperty   `json:"status,omitempty"`
+}
+
+type CustomerRecord struct {
+	ID         string             `json:"id,omitempty"`
+	Properties CustomerProperties `json:"properties"`
+}
+
+type CustomerProperties struct {
+	Title        TitleProperty    `json:"title"`
+	BillingEmail EmailProperty    `json:"billing_email,omitempty"`
+	BillingTo    RichTextProperty `json:"billing_to,omitempty"`
+	SendMethod   SelectProperty   `json:"send_method,omitempty"`
+	CustomerCode RichTextProperty `json:"customer_code,omitempty"`
+	Memo         RichTextProperty `json:"memo,omitempty"`
+}
+
+type InvoiceRecord struct {
+	ID         string            `json:"id,omitempty"`
+	Properties InvoiceProperties `json:"properties"`
+}
+
+type InvoiceProperties struct {
+	Title          TitleProperty    `json:"title"`
+	Customer       RelationProperty `json:"customer,omitempty"`
+	BillingDate    DateProperty     `json:"billing_date,omitempty"`
+	BillingPeriod  RichTextProperty `json:"billing_period,omitempty"`
+	TotalAmount    RollupProperty   `json:"total_amount,omitempty"`
+	Items          RelationProperty `json:"items,omitempty"`
+	PDFURL         URLProperty      `json:"pdf_url,omitempty"`
+	ApprovalStatus StatusProperty   `json:"approval_status,omitempty"`
+	EmailStatus    SelectProperty   `json:"email_status,omitempty"`
+	PaymentDue     RollupProperty   `json:"payment_due,omitempty"`
+}
+
+type CashflowRecord struct {
+	ID         string             `json:"id,omitempty"`
+	Properties CashflowProperties `json:"properties"`
+}
+
+type CashflowProperties struct {
+	Date           DateProperty    `json:"date,omitempty"`
+	OpeningBalance NumberProperty  `json:"opening_balance,omitempty"`
+	CashIn         NumberProperty  `json:"cash_in,omitempty"`
+	CashOut        NumberProperty  `json:"cash_out,omitempty"`
+	NetChange      NumberProperty  `json:"net_change,omitempty"`
+	ClosingBalance NumberProperty  `json:"closing_balance,omitempty"`
+	RiskFlag       FormulaProperty `json:"risk_flag,omitempty"`
+}
+
+type TitleProperty struct {
+	Type  string           `json:"type,omitempty"`
+	Title []RichTextObject `json:"title"`
+}
+
+type RichTextProperty struct {
+	Type     string           `json:"type,omitempty"`
+	RichText []RichTextObject `json:"rich_text"`
+}
+
+type RichTextObject struct {
+	Type      string       `json:"type,omitempty"`
+	PlainText string       `json:"plain_text,omitempty"`
+	Text      *TextContent `json:"text,omitempty"`
+}
+
+type TextContent struct {
+	Content string `json:"content"`
+}
+
+type RelationProperty struct {
+	Type     string        `json:"type,omitempty"`
+	Relation []RelationRef `json:"relation"`
+}
+
+type RelationRef struct {
+	ID string `json:"id"`
+}
+
+type DateProperty struct {
+	Type string     `json:"type,omitempty"`
+	Date *DateValue `json:"date,omitempty"`
+}
+
+type DateValue struct {
+	Start string `json:"start"`
+	End   string `json:"end,omitempty"`
+}
+
+type NumberProperty struct {
+	Type   string   `json:"type,omitempty"`
+	Number *float64 `json:"number,omitempty"`
+}
+
+type SelectProperty struct {
+	Type   string        `json:"type,omitempty"`
+	Select *SelectOption `json:"select,omitempty"`
+}
+
+type StatusProperty struct {
+	Type   string        `json:"type,omitempty"`
+	Select *SelectOption `json:"select,omitempty"`
+	Status *SelectOption `json:"status,omitempty"`
+}
+
+type SelectOption struct {
+	Name string `json:"name"`
+}
+
+type CheckboxProperty struct {
+	Type     string `json:"type,omitempty"`
+	Checkbox bool   `json:"checkbox"`
+}
+
+type FormulaProperty struct {
+	Type    string        `json:"type,omitempty"`
+	Formula *FormulaValue `json:"formula,omitempty"`
+}
+
+type FormulaValue struct {
+	Type   string   `json:"type"`
+	String *string  `json:"string,omitempty"`
+	Number *float64 `json:"number,omitempty"`
+}
+
+type RollupProperty struct {
+	Type   string       `json:"type,omitempty"`
+	Rollup *RollupValue `json:"rollup,omitempty"`
+}
+
+type RollupValue struct {
+	Type   string     `json:"type"`
+	Number *float64   `json:"number,omitempty"`
+	Date   *DateValue `json:"date,omitempty"`
+}
+
+type EmailProperty struct {
+	Type     string           `json:"type,omitempty"`
+	Email    string           `json:"email,omitempty"`
+	RichText []RichTextObject `json:"rich_text,omitempty"`
+}
+
+type URLProperty struct {
+	Type  string       `json:"type,omitempty"`
+	URL   string       `json:"url,omitempty"`
+	Files []FileObject `json:"files,omitempty"`
+}
+
+type FileObject struct {
+	Name     string        `json:"name,omitempty"`
+	External *ExternalFile `json:"external,omitempty"`
+}
+
+type ExternalFile struct {
+	URL string `json:"url"`
+}

--- a/internal/domain/notion_test.go
+++ b/internal/domain/notion_test.go
@@ -1,0 +1,215 @@
+package domain
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestTransactionRecordJSONRoundTrip(t *testing.T) {
+	record := TransactionRecord{
+		ID: "tx-1",
+		Properties: TransactionProperties{
+			Title:           titleProperty("12月保守費"),
+			Customer:        RelationProperty{Type: "relation", Relation: []RelationRef{{ID: "customer-1"}}},
+			CashDate:        dateProperty("2025-12-31"),
+			Amount:          numberProperty(120000),
+			Category:        selectProperty("売上"),
+			IncludeCashflow: CheckboxProperty{Type: "checkbox", Checkbox: true},
+			Description:     richTextProperty("月次保守"),
+			Qty:             numberProperty(1),
+			UnitPrice:       numberProperty(120000),
+			LineTotal:       formulaNumberProperty(120000),
+			BillingDate:     dateProperty("2025-12-31"),
+			PaymentDue:      dateProperty("2026-01-31"),
+			Invoice:         RelationProperty{Type: "relation", Relation: []RelationRef{{ID: "invoice-1"}}},
+			Status:          statusProperty("未請求"),
+		},
+	}
+
+	assertJSONRoundTrip(t, record)
+}
+
+func TestCustomerRecordJSONRoundTrip(t *testing.T) {
+	record := CustomerRecord{
+		ID: "customer-1",
+		Properties: CustomerProperties{
+			Title: titleProperty("株式会社サンプル"),
+			BillingEmail: EmailProperty{
+				Type:  "email",
+				Email: "billing@example.com",
+			},
+			BillingTo:    richTextProperty("株式会社サンプル 御中"),
+			SendMethod:   selectProperty("メール"),
+			CustomerCode: richTextProperty("AB"),
+			Memo:         richTextProperty("優先顧客"),
+		},
+	}
+
+	assertJSONRoundTrip(t, record)
+}
+
+func TestInvoiceRecordJSONRoundTrip(t *testing.T) {
+	record := InvoiceRecord{
+		ID: "invoice-1",
+		Properties: InvoiceProperties{
+			Title:         titleProperty("S-AB202512-01"),
+			Customer:      RelationProperty{Type: "relation", Relation: []RelationRef{{ID: "customer-1"}}},
+			BillingDate:   dateProperty("2025-12-31"),
+			BillingPeriod: richTextProperty("2025-12"),
+			TotalAmount:   rollupNumberProperty(120000),
+			Items:         RelationProperty{Type: "relation", Relation: []RelationRef{{ID: "tx-1"}}},
+			PDFURL: URLProperty{
+				Type: "files",
+				Files: []FileObject{{
+					Name: "invoice.pdf",
+					External: &ExternalFile{
+						URL: "https://example.com/invoice.pdf",
+					},
+				}},
+			},
+			ApprovalStatus: selectOrStatusProperty("select", "ドラフト"),
+			EmailStatus:    selectProperty("未送信"),
+			PaymentDue:     rollupDateProperty("2026-01-31"),
+		},
+	}
+
+	assertJSONRoundTrip(t, record)
+}
+
+func TestCashflowRecordJSONRoundTrip(t *testing.T) {
+	record := CashflowRecord{
+		ID: "cashflow-1",
+		Properties: CashflowProperties{
+			Date:           dateProperty("2025-12-31"),
+			OpeningBalance: numberProperty(500000),
+			CashIn:         numberProperty(120000),
+			CashOut:        numberProperty(30000),
+			NetChange:      numberProperty(90000),
+			ClosingBalance: numberProperty(590000),
+			RiskFlag:       formulaStringProperty("safe"),
+		},
+	}
+
+	assertJSONRoundTrip(t, record)
+}
+
+func assertJSONRoundTrip[T any](t *testing.T, record T) {
+	t.Helper()
+
+	data, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var got T
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, record) {
+		t.Fatalf("round-trip mismatch: got %#v want %#v", got, record)
+	}
+}
+
+func titleProperty(content string) TitleProperty {
+	return TitleProperty{
+		Type:  "title",
+		Title: []RichTextObject{textObject(content)},
+	}
+}
+
+func richTextProperty(content string) RichTextProperty {
+	return RichTextProperty{
+		Type:     "rich_text",
+		RichText: []RichTextObject{textObject(content)},
+	}
+}
+
+func textObject(content string) RichTextObject {
+	return RichTextObject{
+		Type:      "text",
+		PlainText: content,
+		Text: &TextContent{
+			Content: content,
+		},
+	}
+}
+
+func dateProperty(start string) DateProperty {
+	return DateProperty{
+		Type: "date",
+		Date: &DateValue{Start: start},
+	}
+}
+
+func numberProperty(value float64) NumberProperty {
+	return NumberProperty{
+		Type:   "number",
+		Number: &value,
+	}
+}
+
+func selectProperty(name string) SelectProperty {
+	return SelectProperty{
+		Type: "select",
+		Select: &SelectOption{
+			Name: name,
+		},
+	}
+}
+
+func statusProperty(name string) StatusProperty {
+	return selectOrStatusProperty("status", name)
+}
+
+func selectOrStatusProperty(kind, name string) StatusProperty {
+	property := StatusProperty{Type: kind}
+	option := &SelectOption{Name: name}
+	if kind == "select" {
+		property.Select = option
+		return property
+	}
+	property.Status = option
+	return property
+}
+
+func formulaNumberProperty(value float64) FormulaProperty {
+	return FormulaProperty{
+		Type: "formula",
+		Formula: &FormulaValue{
+			Type:   "number",
+			Number: &value,
+		},
+	}
+}
+
+func formulaStringProperty(value string) FormulaProperty {
+	return FormulaProperty{
+		Type: "formula",
+		Formula: &FormulaValue{
+			Type:   "string",
+			String: &value,
+		},
+	}
+}
+
+func rollupNumberProperty(value float64) RollupProperty {
+	return RollupProperty{
+		Type: "rollup",
+		Rollup: &RollupValue{
+			Type:   "number",
+			Number: &value,
+		},
+	}
+}
+
+func rollupDateProperty(start string) RollupProperty {
+	return RollupProperty{
+		Type: "rollup",
+		Rollup: &RollupValue{
+			Type: "date",
+			Date: &DateValue{Start: start},
+		},
+	}
+}


### PR DESCRIPTION
fixes #2

## Summary
1. HLD に沿って `internal/config.Config` と `LoadFromLookup` を追加し、必須環境変数の不足を明示的な error にした。
2. Transactions / Customers / Invoices / Cashflow の最小 Notion record struct と property 型を追加し、複数候補のあるプロパティも受けられるようにした。
3. config / domain / acceptance テストを追加し、JSON round-trip と設定読み込みを `go test ./...` で確認した。

## Changes
### fb2bc76 fixes #2 ドメイン型と設定土台を追加
* Config と環境変数検証を追加
* Notion record struct と property 型を追加
* issue #2 の受入テストと作業記録を追加

## Comment
- `billing_email` `pdf_url` `approval_status` は HLD 上の複数候補を受けられる形にしているので、後続実装でどの Notion 設定を採るか確認してください。
- `PDFTK_PATH` は未指定時に `pdftk` を使う前提です。Lambda 配置時の実行パス設定をレビューしてください。