### PR TITLE
fixes #3 Notion client薄層実装

### DIFF
--- a/ai/tasks/todo.md
+++ b/ai/tasks/todo.md
@@ -116,3 +116,39 @@
 - `final-integrator` の agent 指示を更新し、subtask 完了時 commit 必須を親 orchestration と整合させた
 - `ai/tasks/lesson.md` に恒久ルールとして「subtask は完了時に必ず commit」を追記した
 - `rg` と `git diff` で関連ファイルの表記が一致していることを確認した
+
+## 2026-04-07 issue #3 実装計画
+
+- [x] `AGENTS.md` `docs/ARCHITECTURES.md` `docs/HLD.md` `ai/tasks/*.md` と issue #3 を確認する
+- [x] `issue#3` 用 worktree `/home/user/workspaces/notion-invoice-with-lambda-worktrees/issue-3` を作成する
+- [x] issue #3 の feature-level integration test を追加し、受け入れ条件を固定する
+- [ ] `http-core` subtask で Notion HTTP クライアント基盤と 429/5xx エラー分類を追加する
+- [ ] `database-ops` subtask で Transactions / Customers / Invoices / Cashflow の Query / Upsert API を追加する
+- [ ] subtask ごとの review と commit を完了し、issue branch に取り込む
+- [ ] issue 全体テスト、最終 review、最終 commit、PR 作成を行う
+
+### Subtasks
+
+- [ ] `notion-client-core` - 共通 request 生成、認証ヘッダ、レスポンス処理、429 / 5xx / 4xx の分類を固定する
+- [ ] `notion-query-upsert` - DB ごとの Query / Upsert を DTO から HTTP へ変換し、Notion の endpoint と payload を固定する
+- [ ] `notion-client-tests` - 正常系、429、5xx、DTO→HTTP リクエスト変換を feature-level test で固定する
+
+### Acceptance
+
+- [ ] 正常系で Notion Query / Upsert が想定 endpoint、method、header、body で呼ばれる
+- [ ] 429 は rate limit エラーとして識別され、5xx は server error として識別される
+- [ ] 正常 / 異常レスポンスで API の返り値とエラーが安定する
+
+### Worktree 方針
+
+- issue worktree は `/home/user/workspaces/notion-invoice-with-lambda-worktrees/issue-3` を使用する
+- subtask worktree は `/home/user/workspaces/notion-invoice-with-lambda-worktrees/issue-3-<subtask-slug>` を使用する
+- issue worktree と subtask worktree は役割を分離し、同一 worktree の branch 往復はしない
+
+### Review
+
+- issue #3 は Notion API の薄い HTTP 層であり、業務ロジックや再試行戦略はこの issue に含めない
+- HLD 4.7 の「429 / 5xx はログ出力して即終了、retry しない」を支えるエラー種別化を土台として実装する
+- Query / Upsert は issue 記述を優先し、Transactions / Customers / Invoices / Cashflow ごとの最小 API に留める
+- `internal/acceptance/issue3_feature_test.go` を追加し、Query / Upsert の HTTP 変換と 429 / 5xx の分類を固定した
+- `GOCACHE=/tmp/notion-invoice-issue3-go-build GOMODCACHE=/home/user/workspaces/notion-invoice-with-lambda/.cache/gomod GOPROXY=off go test ./internal/acceptance` は `internal/notion` 未実装のため失敗した

--- a/ai/tasks/todo.md
+++ b/ai/tasks/todo.md
@@ -122,22 +122,22 @@
 - [x] `AGENTS.md` `docs/ARCHITECTURES.md` `docs/HLD.md` `ai/tasks/*.md` と issue #3 を確認する
 - [x] `issue#3` 用 worktree `/home/user/workspaces/notion-invoice-with-lambda-worktrees/issue-3` を作成する
 - [x] issue #3 の feature-level integration test を追加し、受け入れ条件を固定する
-- [ ] `http-core` subtask で Notion HTTP クライアント基盤と 429/5xx エラー分類を追加する
-- [ ] `database-ops` subtask で Transactions / Customers / Invoices / Cashflow の Query / Upsert API を追加する
-- [ ] subtask ごとの review と commit を完了し、issue branch に取り込む
+- [x] `http-core` subtask で Notion HTTP クライアント基盤と 429/5xx エラー分類を追加する
+- [x] `database-ops` subtask で Transactions / Customers / Invoices / Cashflow の Query / Upsert API を追加する
+- [x] subtask ごとの review と commit を完了し、issue branch に取り込む
 - [ ] issue 全体テスト、最終 review、最終 commit、PR 作成を行う
 
 ### Subtasks
 
-- [ ] `notion-client-core` - 共通 request 生成、認証ヘッダ、レスポンス処理、429 / 5xx / 4xx の分類を固定する
-- [ ] `notion-query-upsert` - DB ごとの Query / Upsert を DTO から HTTP へ変換し、Notion の endpoint と payload を固定する
-- [ ] `notion-client-tests` - 正常系、429、5xx、DTO→HTTP リクエスト変換を feature-level test で固定する
+- [x] `notion-client-core` - 共通 request 生成、認証ヘッダ、レスポンス処理、429 / 5xx / 4xx の分類を固定する
+- [x] `notion-query-upsert` - DB ごとの Query / Upsert を DTO から HTTP へ変換し、Notion の endpoint と payload を固定する
+- [x] `notion-client-tests` - 正常系、429、5xx、DTO→HTTP リクエスト変換を feature-level test で固定する
 
 ### Acceptance
 
-- [ ] 正常系で Notion Query / Upsert が想定 endpoint、method、header、body で呼ばれる
-- [ ] 429 は rate limit エラーとして識別され、5xx は server error として識別される
-- [ ] 正常 / 異常レスポンスで API の返り値とエラーが安定する
+- [x] 正常系で Notion Query / Upsert が想定 endpoint、method、header、body で呼ばれる
+- [x] 429 は rate limit エラーとして識別され、5xx は server error として識別される
+- [x] 正常 / 異常レスポンスで API の返り値とエラーが安定する
 
 ### Worktree 方針
 
@@ -150,5 +150,7 @@
 - issue #3 は Notion API の薄い HTTP 層であり、業務ロジックや再試行戦略はこの issue に含めない
 - HLD 4.7 の「429 / 5xx はログ出力して即終了、retry しない」を支えるエラー種別化を土台として実装する
 - Query / Upsert は issue 記述を優先し、Transactions / Customers / Invoices / Cashflow ごとの最小 API に留める
-- `internal/acceptance/issue3_feature_test.go` を追加し、Query / Upsert の HTTP 変換と 429 / 5xx の分類を固定した
-- `GOCACHE=/tmp/notion-invoice-issue3-go-build GOMODCACHE=/home/user/workspaces/notion-invoice-with-lambda/.cache/gomod GOPROXY=off go test ./internal/acceptance` は `internal/notion` 未実装のため失敗した
+- `internal/notion.Client` に共通 HTTP 実行、Authorization / Notion-Version / Content-Type ヘッダ、429 / 5xx / 4xx 分類を追加した
+- DB ごとの `Query*` / `Upsert*` wrapper を追加し、create は `/v1/pages` + `parent.database_id`、update は `/v1/pages/{id}` に変換する
+- feature-level test と unit test の `httptest` 依存を fake `HTTPDoer` へ置き換え、sandbox でも受け入れ条件を検証できるようにした
+- `env GOCACHE=/tmp/notion-issue3-all-go-build GOMODCACHE=/home/user/workspaces/notion-invoice-with-lambda/.cache/gomod GOPROXY=off go test ./...` は成功した

--- a/internal/acceptance/issue3_feature_test.go
+++ b/internal/acceptance/issue3_feature_test.go
@@ -1,0 +1,366 @@
+package acceptance_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/domain"
+	"github.com/irukasano/notion-invoice-with-lambda/internal/notion"
+)
+
+func TestIssue3Feature_NotionClient(t *testing.T) {
+	t.Run("query uses notion database endpoint and parses records", func(t *testing.T) {
+		var got requestCapture
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = captureRequest(t, r)
+			writeJSON(t, w, map[string]any{
+				"results": []map[string]any{{
+					"id": "tx-1",
+					"properties": map[string]any{
+						"title": map[string]any{
+							"type": "title",
+							"title": []map[string]any{{
+								"type":       "text",
+								"plain_text": "12月保守費",
+								"text": map[string]any{
+									"content": "12月保守費",
+								},
+							}},
+						},
+					},
+				}},
+				"has_more":    false,
+				"next_cursor": nil,
+			})
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+
+		response, err := client.QueryTransactions(context.Background(), notion.QueryDatabaseRequest{
+			Filter: map[string]any{
+				"property": "status",
+				"status": map[string]any{
+					"equals": "未請求",
+				},
+			},
+			PageSize: 10,
+		})
+		if err != nil {
+			t.Fatalf("QueryTransactions returned error: %v", err)
+		}
+		if got.Method != http.MethodPost {
+			t.Fatalf("method mismatch: got %q", got.Method)
+		}
+		if got.Path != "/v1/databases/tx-db/query" {
+			t.Fatalf("path mismatch: got %q", got.Path)
+		}
+		if got.Authorization != "Bearer notion-secret" {
+			t.Fatalf("authorization mismatch: got %q", got.Authorization)
+		}
+		if got.NotionVersion == "" {
+			t.Fatal("Notion-Version header is empty")
+		}
+		if got.ContentType != "application/json" {
+			t.Fatalf("content-type mismatch: got %q", got.ContentType)
+		}
+		if pageSize := got.Body["page_size"]; pageSize != float64(10) {
+			t.Fatalf("page_size mismatch: got %#v", pageSize)
+		}
+		filter, ok := got.Body["filter"].(map[string]any)
+		if !ok {
+			t.Fatalf("filter type mismatch: got %#v", got.Body["filter"])
+		}
+		if filter["property"] != "status" {
+			t.Fatalf("filter property mismatch: got %#v", filter["property"])
+		}
+		if len(response.Results) != 1 {
+			t.Fatalf("result count mismatch: got %d", len(response.Results))
+		}
+		if response.Results[0].ID != "tx-1" {
+			t.Fatalf("record id mismatch: got %q", response.Results[0].ID)
+		}
+	})
+
+	t.Run("upsert maps create and update to pages endpoint", func(t *testing.T) {
+		var calls []requestCapture
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, captureRequest(t, r))
+			switch len(calls) {
+			case 1:
+				writeJSON(t, w, map[string]any{
+					"id": "customer-1",
+					"properties": map[string]any{
+						"title": map[string]any{
+							"type": "title",
+							"title": []map[string]any{{
+								"type":       "text",
+								"plain_text": "株式会社サンプル",
+								"text": map[string]any{
+									"content": "株式会社サンプル",
+								},
+							}},
+						},
+					},
+				})
+			case 2:
+				writeJSON(t, w, map[string]any{
+					"id": "invoice-1",
+					"properties": map[string]any{
+						"title": map[string]any{
+							"type": "title",
+							"title": []map[string]any{{
+								"type":       "text",
+								"plain_text": "S-AB202512-01",
+								"text": map[string]any{
+									"content": "S-AB202512-01",
+								},
+							}},
+						},
+					},
+				})
+			default:
+				t.Fatalf("unexpected call count: %d", len(calls))
+			}
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+
+		customer, err := client.UpsertCustomer(context.Background(), notion.UpsertPageRequest[domain.CustomerProperties]{
+			Properties: domain.CustomerProperties{
+				Title: titleProperty("株式会社サンプル"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("UpsertCustomer returned error: %v", err)
+		}
+		if customer.ID != "customer-1" {
+			t.Fatalf("customer id mismatch: got %q", customer.ID)
+		}
+
+		invoice, err := client.UpsertInvoice(context.Background(), notion.UpsertPageRequest[domain.InvoiceProperties]{
+			PageID: "invoice-1",
+			Properties: domain.InvoiceProperties{
+				Title: titleProperty("S-AB202512-01"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("UpsertInvoice returned error: %v", err)
+		}
+		if invoice.ID != "invoice-1" {
+			t.Fatalf("invoice id mismatch: got %q", invoice.ID)
+		}
+		if len(calls) != 2 {
+			t.Fatalf("call count mismatch: got %d", len(calls))
+		}
+		if calls[0].Method != http.MethodPost || calls[0].Path != "/v1/pages" {
+			t.Fatalf("create endpoint mismatch: %#v", calls[0])
+		}
+		parent, ok := calls[0].Body["parent"].(map[string]any)
+		if !ok {
+			t.Fatalf("parent type mismatch: got %#v", calls[0].Body["parent"])
+		}
+		if parent["database_id"] != "customers-db" {
+			t.Fatalf("parent database mismatch: got %#v", parent["database_id"])
+		}
+		if calls[1].Method != http.MethodPatch || calls[1].Path != "/v1/pages/invoice-1" {
+			t.Fatalf("update endpoint mismatch: %#v", calls[1])
+		}
+		if _, exists := calls[1].Body["parent"]; exists {
+			t.Fatalf("update request should not contain parent: %#v", calls[1].Body)
+		}
+	})
+
+	t.Run("rate limit responses are classified", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			http.Error(w, `{"message":"rate limited"}`, http.StatusTooManyRequests)
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+		_, err := client.QueryCashflow(context.Background(), notion.QueryDatabaseRequest{})
+		if err == nil {
+			t.Fatal("QueryCashflow returned nil error")
+		}
+
+		var rateLimitErr *notion.RateLimitError
+		if !errors.As(err, &rateLimitErr) {
+			t.Fatalf("expected RateLimitError, got %T", err)
+		}
+		if rateLimitErr.StatusCode != http.StatusTooManyRequests {
+			t.Fatalf("status code mismatch: got %d", rateLimitErr.StatusCode)
+		}
+		if requestCount != 1 {
+			t.Fatalf("unexpected retry count: got %d want 1", requestCount)
+		}
+	})
+
+	t.Run("5xx responses are classified", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			http.Error(w, `{"message":"server error"}`, http.StatusBadGateway)
+		}))
+		defer server.Close()
+
+		client := newTestClient(t, server)
+		_, err := client.QueryInvoices(context.Background(), notion.QueryDatabaseRequest{})
+		if err == nil {
+			t.Fatal("QueryInvoices returned nil error")
+		}
+
+		var serverErr *notion.ServerError
+		if !errors.As(err, &serverErr) {
+			t.Fatalf("expected ServerError, got %T", err)
+		}
+		if serverErr.StatusCode != http.StatusBadGateway {
+			t.Fatalf("status code mismatch: got %d", serverErr.StatusCode)
+		}
+		if requestCount != 1 {
+			t.Fatalf("unexpected retry count: got %d want 1", requestCount)
+		}
+	})
+}
+
+type requestCapture struct {
+	Method        string
+	Path          string
+	Authorization string
+	NotionVersion string
+	ContentType   string
+	Body          map[string]any
+}
+
+func newTestClient(t *testing.T, server *httptest.Server) *notion.Client {
+	t.Helper()
+
+	return notion.NewClient(notion.ClientConfig{
+		BaseURL: server.URL,
+		Token:   "notion-secret",
+		DatabaseIDs: notion.DatabaseIDs{
+			Transactions: "tx-db",
+			Customers:    "customers-db",
+			Invoices:     "invoices-db",
+			Cashflow:     "cashflow-db",
+		},
+	}, server.Client())
+}
+
+func captureRequest(t *testing.T, r *http.Request) requestCapture {
+	t.Helper()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll returned error: %v", err)
+	}
+	defer r.Body.Close()
+
+	captured := requestCapture{
+		Method:        r.Method,
+		Path:          r.URL.Path,
+		Authorization: r.Header.Get("Authorization"),
+		NotionVersion: r.Header.Get("Notion-Version"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          map[string]any{},
+	}
+	if len(body) == 0 {
+		return captured
+	}
+	if err := json.Unmarshal(body, &captured.Body); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	return captured
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, body map[string]any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Fatalf("json.NewEncoder returned error: %v", err)
+	}
+}
+
+func titleProperty(content string) domain.TitleProperty {
+	return domain.TitleProperty{
+		Type: "title",
+		Title: []domain.RichTextObject{{
+			Type:      "text",
+			PlainText: content,
+			Text: &domain.TextContent{
+				Content: content,
+			},
+		}},
+	}
+}
+
+func richTextProperty(content string) domain.RichTextProperty {
+	return domain.RichTextProperty{
+		Type: "rich_text",
+		RichText: []domain.RichTextObject{{
+			Type:      "text",
+			PlainText: content,
+			Text: &domain.TextContent{
+				Content: content,
+			},
+		}},
+	}
+}
+
+func emailProperty(email string) domain.EmailProperty {
+	return domain.EmailProperty{
+		Type:  "email",
+		Email: email,
+	}
+}
+
+func dateProperty(start string) domain.DateProperty {
+	return domain.DateProperty{
+		Type: "date",
+		Date: &domain.DateValue{
+			Start: start,
+		},
+	}
+}
+
+func numberProperty(value float64) domain.NumberProperty {
+	return domain.NumberProperty{
+		Type:   "number",
+		Number: &value,
+	}
+}
+
+func selectProperty(name string) domain.SelectProperty {
+	return domain.SelectProperty{
+		Type: "select",
+		Select: &domain.SelectOption{
+			Name: name,
+		},
+	}
+}
+
+func statusProperty(name string) domain.StatusProperty {
+	return domain.StatusProperty{
+		Type: "status",
+		Status: &domain.SelectOption{
+			Name: name,
+		},
+	}
+}
+
+func relationProperty(id string) domain.RelationProperty {
+	return domain.RelationProperty{
+		Type: "relation",
+		Relation: []domain.RelationRef{{
+			ID: id,
+		}},
+	}
+}

--- a/internal/acceptance/issue3_feature_test.go
+++ b/internal/acceptance/issue3_feature_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/irukasano/notion-invoice-with-lambda/internal/domain"
@@ -16,9 +16,9 @@ import (
 func TestIssue3Feature_NotionClient(t *testing.T) {
 	t.Run("query uses notion database endpoint and parses records", func(t *testing.T) {
 		var got requestCapture
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
 			got = captureRequest(t, r)
-			writeJSON(t, w, map[string]any{
+			return encodeResponse(t, map[string]any{
 				"results": []map[string]any{{
 					"id": "tx-1",
 					"properties": map[string]any{
@@ -36,11 +36,8 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 				}},
 				"has_more":    false,
 				"next_cursor": nil,
-			})
+			}), nil
 		}))
-		defer server.Close()
-
-		client := newTestClient(t, server)
 
 		response, err := client.QueryTransactions(context.Background(), notion.QueryDatabaseRequest{
 			Filter: map[string]any{
@@ -89,11 +86,11 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 
 	t.Run("upsert maps create and update to pages endpoint", func(t *testing.T) {
 		var calls []requestCapture
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
 			calls = append(calls, captureRequest(t, r))
 			switch len(calls) {
 			case 1:
-				writeJSON(t, w, map[string]any{
+				return encodeResponse(t, map[string]any{
 					"id": "customer-1",
 					"properties": map[string]any{
 						"title": map[string]any{
@@ -107,9 +104,9 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 							}},
 						},
 					},
-				})
+				}), nil
 			case 2:
-				writeJSON(t, w, map[string]any{
+				return encodeResponse(t, map[string]any{
 					"id": "invoice-1",
 					"properties": map[string]any{
 						"title": map[string]any{
@@ -123,14 +120,12 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 							}},
 						},
 					},
-				})
+				}), nil
 			default:
 				t.Fatalf("unexpected call count: %d", len(calls))
+				return nil, nil
 			}
 		}))
-		defer server.Close()
-
-		client := newTestClient(t, server)
 
 		customer, err := client.UpsertCustomer(context.Background(), notion.UpsertPageRequest[domain.CustomerProperties]{
 			Properties: domain.CustomerProperties{
@@ -179,13 +174,10 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 
 	t.Run("rate limit responses are classified", func(t *testing.T) {
 		requestCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
 			requestCount++
-			http.Error(w, `{"message":"rate limited"}`, http.StatusTooManyRequests)
+			return jsonResponse(http.StatusTooManyRequests, `{"message":"rate limited"}`), nil
 		}))
-		defer server.Close()
-
-		client := newTestClient(t, server)
 		_, err := client.QueryCashflow(context.Background(), notion.QueryDatabaseRequest{})
 		if err == nil {
 			t.Fatal("QueryCashflow returned nil error")
@@ -205,13 +197,10 @@ func TestIssue3Feature_NotionClient(t *testing.T) {
 
 	t.Run("5xx responses are classified", func(t *testing.T) {
 		requestCount := 0
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		client := newTestClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
 			requestCount++
-			http.Error(w, `{"message":"server error"}`, http.StatusBadGateway)
+			return jsonResponse(http.StatusBadGateway, `{"message":"server error"}`), nil
 		}))
-		defer server.Close()
-
-		client := newTestClient(t, server)
 		_, err := client.QueryInvoices(context.Background(), notion.QueryDatabaseRequest{})
 		if err == nil {
 			t.Fatal("QueryInvoices returned nil error")
@@ -239,11 +228,9 @@ type requestCapture struct {
 	Body          map[string]any
 }
 
-func newTestClient(t *testing.T, server *httptest.Server) *notion.Client {
-	t.Helper()
-
+func newTestClient(httpClient notion.HTTPDoer) *notion.Client {
 	return notion.NewClient(notion.ClientConfig{
-		BaseURL: server.URL,
+		BaseURL: "https://api.notion.test",
 		Token:   "notion-secret",
 		DatabaseIDs: notion.DatabaseIDs{
 			Transactions: "tx-db",
@@ -251,7 +238,7 @@ func newTestClient(t *testing.T, server *httptest.Server) *notion.Client {
 			Invoices:     "invoices-db",
 			Cashflow:     "cashflow-db",
 		},
-	}, server.Client())
+	}, httpClient)
 }
 
 func captureRequest(t *testing.T, r *http.Request) requestCapture {
@@ -280,12 +267,30 @@ func captureRequest(t *testing.T, r *http.Request) requestCapture {
 	return captured
 }
 
-func writeJSON(t *testing.T, w http.ResponseWriter, body map[string]any) {
+type fakeDoer func(*http.Request) (*http.Response, error)
+
+func (f fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func encodeResponse(t *testing.T, body map[string]any) *http.Response {
 	t.Helper()
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(body); err != nil {
+	builder := &strings.Builder{}
+	if err := json.NewEncoder(builder).Encode(body); err != nil {
 		t.Fatalf("json.NewEncoder returned error: %v", err)
+	}
+
+	return jsonResponse(http.StatusOK, builder.String())
+}
+
+func jsonResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
 	}
 }
 

--- a/internal/notion/client.go
+++ b/internal/notion/client.go
@@ -1,0 +1,150 @@
+package notion
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	defaultBaseURL       = "https://api.notion.com"
+	defaultNotionVersion = "2022-06-28"
+)
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type DatabaseIDs struct {
+	Transactions string
+	Customers    string
+	Invoices     string
+	Cashflow     string
+}
+
+type ClientConfig struct {
+	BaseURL       string
+	Token         string
+	NotionVersion string
+	DatabaseIDs   DatabaseIDs
+}
+
+type Client struct {
+	baseURL       string
+	token         string
+	notionVersion string
+	databaseIDs   DatabaseIDs
+	httpClient    HTTPDoer
+}
+
+func NewClient(cfg ClientConfig, httpClient HTTPDoer) *Client {
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+
+	notionVersion := cfg.NotionVersion
+	if notionVersion == "" {
+		notionVersion = defaultNotionVersion
+	}
+
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		baseURL:       baseURL,
+		token:         cfg.Token,
+		notionVersion: notionVersion,
+		databaseIDs:   cfg.DatabaseIDs,
+		httpClient:    httpClient,
+	}
+}
+
+func (c *Client) queryDatabase(ctx context.Context, databaseID string, payload QueryDatabaseRequest, out any) error {
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/v1/databases/"+databaseID+"/query", payload)
+	if err != nil {
+		return err
+	}
+
+	return c.doJSON(req, out)
+}
+
+func (c *Client) upsertPage(ctx context.Context, databaseID, pageID string, properties any, out any) error {
+	method := http.MethodPost
+	path := "/v1/pages"
+	body := map[string]any{
+		"parent": map[string]string{
+			"database_id": databaseID,
+		},
+		"properties": properties,
+	}
+
+	if pageID != "" {
+		method = http.MethodPatch
+		path = "/v1/pages/" + pageID
+		body = map[string]any{
+			"properties": properties,
+		}
+	}
+
+	req, err := c.newJSONRequest(ctx, method, path, body)
+	if err != nil {
+		return err
+	}
+
+	return c.doJSON(req, out)
+}
+
+func (c *Client) newJSONRequest(ctx context.Context, method, path string, payload any) (*http.Request, error) {
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Notion-Version", c.notionVersion)
+
+	return req, nil
+}
+
+func (c *Client) doJSON(req *http.Request, out any) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return classifyHTTPError(req, resp.StatusCode, body)
+	}
+
+	if out == nil || len(body) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode notion response: %w", err)
+	}
+
+	return nil
+}

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -1,0 +1,142 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewClientAppliesDefaults(t *testing.T) {
+	client := NewClient(ClientConfig{Token: "secret"}, nil)
+
+	if client.baseURL != defaultBaseURL {
+		t.Fatalf("baseURL mismatch: got %q", client.baseURL)
+	}
+	if client.notionVersion != defaultNotionVersion {
+		t.Fatalf("Notion version mismatch: got %q", client.notionVersion)
+	}
+	if client.httpClient == nil {
+		t.Fatal("httpClient is nil")
+	}
+}
+
+func TestNewJSONRequestSetsHeaders(t *testing.T) {
+	client := NewClient(ClientConfig{
+		BaseURL:       "https://api.notion.test/",
+		Token:         "secret",
+		NotionVersion: "2022-06-28",
+	}, nil)
+
+	req, err := client.newJSONRequest(context.Background(), http.MethodPost, "/v1/pages", map[string]string{
+		"foo": "bar",
+	})
+	if err != nil {
+		t.Fatalf("newJSONRequest returned error: %v", err)
+	}
+
+	if req.URL.String() != "https://api.notion.test/v1/pages" {
+		t.Fatalf("url mismatch: got %q", req.URL.String())
+	}
+	if req.Header.Get("Authorization") != "Bearer secret" {
+		t.Fatalf("authorization mismatch: got %q", req.Header.Get("Authorization"))
+	}
+	if req.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("content-type mismatch: got %q", req.Header.Get("Content-Type"))
+	}
+	if req.Header.Get("Notion-Version") != "2022-06-28" {
+		t.Fatalf("version mismatch: got %q", req.Header.Get("Notion-Version"))
+	}
+}
+
+func TestDoJSONDecodesResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"id": "page-1"})
+	}))
+	defer server.Close()
+
+	client := NewClient(ClientConfig{BaseURL: server.URL}, server.Client())
+	req, err := client.newJSONRequest(context.Background(), http.MethodGet, "/v1/pages/page-1", nil)
+	if err != nil {
+		t.Fatalf("newJSONRequest returned error: %v", err)
+	}
+
+	var got struct {
+		ID string `json:"id"`
+	}
+	if err := client.doJSON(req, &got); err != nil {
+		t.Fatalf("doJSON returned error: %v", err)
+	}
+	if got.ID != "page-1" {
+		t.Fatalf("id mismatch: got %q", got.ID)
+	}
+}
+
+func TestDoJSONClassifiesErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		assert   func(*testing.T, error)
+	}{
+		{
+			name:   "rate limit",
+			status: http.StatusTooManyRequests,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				var target *RateLimitError
+				if !errors.As(err, &target) {
+					t.Fatalf("unexpected error type: got %T", err)
+				}
+			},
+		},
+		{
+			name:   "server error",
+			status: http.StatusBadGateway,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				var target *ServerError
+				if !errors.As(err, &target) {
+					t.Fatalf("unexpected error type: got %T", err)
+				}
+			},
+		},
+		{
+			name:   "client error",
+			status: http.StatusBadRequest,
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				var target *ClientError
+				if !errors.As(err, &target) {
+					t.Fatalf("unexpected error type: got %T", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "boom", tt.status)
+			}))
+			defer server.Close()
+
+			client := NewClient(ClientConfig{BaseURL: server.URL}, server.Client())
+			req, err := client.newJSONRequest(context.Background(), http.MethodGet, "/v1/test", nil)
+			if err != nil {
+				t.Fatalf("newJSONRequest returned error: %v", err)
+			}
+
+			err = client.doJSON(req, nil)
+			if err == nil {
+				t.Fatal("doJSON returned nil error")
+			}
+			tt.assert(t, err)
+		})
+	}
+}

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
-	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -52,13 +53,14 @@ func TestNewJSONRequestSetsHeaders(t *testing.T) {
 }
 
 func TestDoJSONDecodesResponse(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]string{"id": "page-1"})
-	}))
-	defer server.Close()
+	client := NewClient(ClientConfig{BaseURL: "https://api.notion.test"}, fakeDoer(func(req *http.Request) (*http.Response, error) {
+		recorder := &strings.Builder{}
+		if err := json.NewEncoder(recorder).Encode(map[string]string{"id": "page-1"}); err != nil {
+			t.Fatalf("json.NewEncoder returned error: %v", err)
+		}
 
-	client := NewClient(ClientConfig{BaseURL: server.URL}, server.Client())
+		return jsonResponse(http.StatusOK, recorder.String()), nil
+	}))
 	req, err := client.newJSONRequest(context.Background(), http.MethodGet, "/v1/pages/page-1", nil)
 	if err != nil {
 		t.Fatalf("newJSONRequest returned error: %v", err)
@@ -77,9 +79,9 @@ func TestDoJSONDecodesResponse(t *testing.T) {
 
 func TestDoJSONClassifiesErrors(t *testing.T) {
 	tests := []struct {
-		name     string
-		status   int
-		assert   func(*testing.T, error)
+		name   string
+		status int
+		assert func(*testing.T, error)
 	}{
 		{
 			name:   "rate limit",
@@ -121,12 +123,9 @@ func TestDoJSONClassifiesErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				http.Error(w, "boom", tt.status)
+			client := NewClient(ClientConfig{BaseURL: "https://api.notion.test"}, fakeDoer(func(req *http.Request) (*http.Response, error) {
+				return jsonResponse(tt.status, "boom"), nil
 			}))
-			defer server.Close()
-
-			client := NewClient(ClientConfig{BaseURL: server.URL}, server.Client())
 			req, err := client.newJSONRequest(context.Background(), http.MethodGet, "/v1/test", nil)
 			if err != nil {
 				t.Fatalf("newJSONRequest returned error: %v", err)
@@ -138,5 +137,21 @@ func TestDoJSONClassifiesErrors(t *testing.T) {
 			}
 			tt.assert(t, err)
 		})
+	}
+}
+
+type fakeDoer func(*http.Request) (*http.Response, error)
+
+func (f fakeDoer) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
 	}
 }

--- a/internal/notion/databases.go
+++ b/internal/notion/databases.go
@@ -1,0 +1,68 @@
+package notion
+
+import (
+	"context"
+	"errors"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/domain"
+)
+
+var errDatabaseIDRequired = errors.New("notion database id is required")
+
+func (c *Client) QueryTransactions(ctx context.Context, request QueryDatabaseRequest) (QueryDatabaseResponse[domain.TransactionRecord], error) {
+	return queryRecords[domain.TransactionRecord](ctx, c, c.databaseIDs.Transactions, request)
+}
+
+func (c *Client) QueryCustomers(ctx context.Context, request QueryDatabaseRequest) (QueryDatabaseResponse[domain.CustomerRecord], error) {
+	return queryRecords[domain.CustomerRecord](ctx, c, c.databaseIDs.Customers, request)
+}
+
+func (c *Client) QueryInvoices(ctx context.Context, request QueryDatabaseRequest) (QueryDatabaseResponse[domain.InvoiceRecord], error) {
+	return queryRecords[domain.InvoiceRecord](ctx, c, c.databaseIDs.Invoices, request)
+}
+
+func (c *Client) QueryCashflow(ctx context.Context, request QueryDatabaseRequest) (QueryDatabaseResponse[domain.CashflowRecord], error) {
+	return queryRecords[domain.CashflowRecord](ctx, c, c.databaseIDs.Cashflow, request)
+}
+
+func (c *Client) UpsertTransaction(ctx context.Context, request UpsertPageRequest[domain.TransactionProperties]) (domain.TransactionRecord, error) {
+	return upsertRecord[domain.TransactionRecord, domain.TransactionProperties](ctx, c, c.databaseIDs.Transactions, request)
+}
+
+func (c *Client) UpsertCustomer(ctx context.Context, request UpsertPageRequest[domain.CustomerProperties]) (domain.CustomerRecord, error) {
+	return upsertRecord[domain.CustomerRecord, domain.CustomerProperties](ctx, c, c.databaseIDs.Customers, request)
+}
+
+func (c *Client) UpsertInvoice(ctx context.Context, request UpsertPageRequest[domain.InvoiceProperties]) (domain.InvoiceRecord, error) {
+	return upsertRecord[domain.InvoiceRecord, domain.InvoiceProperties](ctx, c, c.databaseIDs.Invoices, request)
+}
+
+func (c *Client) UpsertCashflow(ctx context.Context, request UpsertPageRequest[domain.CashflowProperties]) (domain.CashflowRecord, error) {
+	return upsertRecord[domain.CashflowRecord, domain.CashflowProperties](ctx, c, c.databaseIDs.Cashflow, request)
+}
+
+func queryRecords[T any](ctx context.Context, client *Client, databaseID string, request QueryDatabaseRequest) (QueryDatabaseResponse[T], error) {
+	var response QueryDatabaseResponse[T]
+	if databaseID == "" {
+		return response, errDatabaseIDRequired
+	}
+
+	if err := client.queryDatabase(ctx, databaseID, request, &response); err != nil {
+		return QueryDatabaseResponse[T]{}, err
+	}
+
+	return response, nil
+}
+
+func upsertRecord[T any, P any](ctx context.Context, client *Client, databaseID string, request UpsertPageRequest[P]) (T, error) {
+	var response T
+	if databaseID == "" {
+		return response, errDatabaseIDRequired
+	}
+
+	if err := client.upsertPage(ctx, databaseID, request.PageID, request.Properties, &response); err != nil {
+		return response, err
+	}
+
+	return response, nil
+}

--- a/internal/notion/databases_test.go
+++ b/internal/notion/databases_test.go
@@ -1,0 +1,161 @@
+package notion
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/domain"
+)
+
+func TestQueryTransactionsUsesTransactionsDatabaseID(t *testing.T) {
+	var got requestSnapshot
+	client := testClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
+		got = captureSnapshot(t, r)
+		return encodeResponse(t, map[string]any{
+			"results": []map[string]any{},
+		}), nil
+	}))
+	_, err := client.QueryTransactions(context.Background(), QueryDatabaseRequest{
+		PageSize: 25,
+	})
+	if err != nil {
+		t.Fatalf("QueryTransactions returned error: %v", err)
+	}
+
+	if got.Method != http.MethodPost {
+		t.Fatalf("method mismatch: got %q", got.Method)
+	}
+	if got.Path != "/v1/databases/tx-db/query" {
+		t.Fatalf("path mismatch: got %q", got.Path)
+	}
+	if got.Body["page_size"] != float64(25) {
+		t.Fatalf("page_size mismatch: got %#v", got.Body["page_size"])
+	}
+}
+
+func TestUpsertCashflowCreatesPageInCashflowDatabase(t *testing.T) {
+	var got requestSnapshot
+	client := testClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
+		got = captureSnapshot(t, r)
+		return encodeResponse(t, map[string]any{
+			"id": "cashflow-1",
+		}), nil
+	}))
+	record, err := client.UpsertCashflow(context.Background(), UpsertPageRequest[domain.CashflowProperties]{
+		Properties: domain.CashflowProperties{
+			Date: domain.DateProperty{
+				Type: "date",
+				Date: &domain.DateValue{Start: "2025-12-31"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpsertCashflow returned error: %v", err)
+	}
+	if record.ID != "cashflow-1" {
+		t.Fatalf("record id mismatch: got %q", record.ID)
+	}
+	if got.Method != http.MethodPost {
+		t.Fatalf("method mismatch: got %q", got.Method)
+	}
+	if got.Path != "/v1/pages" {
+		t.Fatalf("path mismatch: got %q", got.Path)
+	}
+	parent, ok := got.Body["parent"].(map[string]any)
+	if !ok {
+		t.Fatalf("parent type mismatch: got %#v", got.Body["parent"])
+	}
+	if parent["database_id"] != "cashflow-db" {
+		t.Fatalf("database mismatch: got %#v", parent["database_id"])
+	}
+}
+
+func TestUpsertInvoiceUpdatesExistingPage(t *testing.T) {
+	var got requestSnapshot
+	client := testClient(fakeDoer(func(r *http.Request) (*http.Response, error) {
+		got = captureSnapshot(t, r)
+		return encodeResponse(t, map[string]any{
+			"id": "invoice-1",
+		}), nil
+	}))
+	record, err := client.UpsertInvoice(context.Background(), UpsertPageRequest[domain.InvoiceProperties]{
+		PageID: "invoice-1",
+		Properties: domain.InvoiceProperties{
+			Title: domain.TitleProperty{
+				Type: "title",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpsertInvoice returned error: %v", err)
+	}
+	if record.ID != "invoice-1" {
+		t.Fatalf("record id mismatch: got %q", record.ID)
+	}
+	if got.Method != http.MethodPatch {
+		t.Fatalf("method mismatch: got %q", got.Method)
+	}
+	if got.Path != "/v1/pages/invoice-1" {
+		t.Fatalf("path mismatch: got %q", got.Path)
+	}
+	if _, ok := got.Body["parent"]; ok {
+		t.Fatalf("unexpected parent in update body: %#v", got.Body)
+	}
+}
+
+type requestSnapshot struct {
+	Method string
+	Path   string
+	Body   map[string]any
+}
+
+func testClient(httpClient HTTPDoer) *Client {
+	return NewClient(ClientConfig{
+		BaseURL: "https://api.notion.test",
+		Token:   "secret",
+		DatabaseIDs: DatabaseIDs{
+			Transactions: "tx-db",
+			Customers:    "customers-db",
+			Invoices:     "invoices-db",
+			Cashflow:     "cashflow-db",
+		},
+	}, httpClient)
+}
+
+func captureSnapshot(t *testing.T, r *http.Request) requestSnapshot {
+	t.Helper()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll returned error: %v", err)
+	}
+	defer r.Body.Close()
+
+	result := requestSnapshot{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Body:   map[string]any{},
+	}
+	if len(body) == 0 {
+		return result
+	}
+	if err := json.Unmarshal(body, &result.Body); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	return result
+}
+
+func encodeResponse(t *testing.T, body map[string]any) *http.Response {
+	t.Helper()
+
+	recorder := &strings.Builder{}
+	if err := json.NewEncoder(recorder).Encode(body); err != nil {
+		t.Fatalf("json.NewEncoder returned error: %v", err)
+	}
+
+	return jsonResponse(http.StatusOK, recorder.String())
+}

--- a/internal/notion/errors.go
+++ b/internal/notion/errors.go
@@ -1,0 +1,54 @@
+package notion
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf(
+		"notion api %s %s returned %d: %s",
+		e.Method,
+		e.Path,
+		e.StatusCode,
+		e.Body,
+	)
+}
+
+type RateLimitError struct {
+	HTTPError
+}
+
+type ServerError struct {
+	HTTPError
+}
+
+type ClientError struct {
+	HTTPError
+}
+
+func classifyHTTPError(req *http.Request, statusCode int, body []byte) error {
+	httpErr := HTTPError{
+		Method:     req.Method,
+		Path:       req.URL.Path,
+		StatusCode: statusCode,
+		Body:       strings.TrimSpace(string(body)),
+	}
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		return &RateLimitError{HTTPError: httpErr}
+	case statusCode >= http.StatusInternalServerError:
+		return &ServerError{HTTPError: httpErr}
+	default:
+		return &ClientError{HTTPError: httpErr}
+	}
+}

--- a/internal/notion/types.go
+++ b/internal/notion/types.go
@@ -1,0 +1,19 @@
+package notion
+
+type QueryDatabaseRequest struct {
+	Filter      map[string]any   `json:"filter,omitempty"`
+	Sorts       []map[string]any `json:"sorts,omitempty"`
+	PageSize    int              `json:"page_size,omitempty"`
+	StartCursor string           `json:"start_cursor,omitempty"`
+}
+
+type QueryDatabaseResponse[T any] struct {
+	Results    []T    `json:"results"`
+	HasMore    bool   `json:"has_more"`
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+type UpsertPageRequest[T any] struct {
+	PageID     string `json:"-"`
+	Properties T      `json:"properties"`
+}


### PR DESCRIPTION
fixes #3

## Summary
1. Notion API 共通 client と 429/5xx/4xx 分類を追加
2. 4 DB 向け Query / Upsert wrapper と request 変換を追加
3. feature test と unit test を整備し `go test ./...` を通過

## Changes
### a3a2ebe refs #3 Notion client受け入れ条件追加
* issue #3 の計画と subtask を todo に記録
* Notion client の feature-level red test を追加
* Query / Upsert と 429 / 5xx の期待値を固定

### d7ba298 refs #3 Notion client core追加
* 共通 HTTP client と JSON request 処理を追加
* 429 / 5xx / 4xx のエラー分類を追加
* core 層の unit test を追加

### aa62cba refs #3 Query Upsert API追加
* DB ごとの Query / Upsert wrapper を追加
* parent database_id と path の unit test を追加
* client test を socket 不要な形へ合わせた

### b3fe491 fixes #3 Notion client薄層実装
* feature test を fake HTTPDoer へ切替
* issue #3 の進捗と検証結果を todo に追記
* 全体テスト成功後の統合状態を記録

## Comment
- 後続の Lambda ロジックから `internal/notion` の DTO 形状をそのまま使えるか
- `Notion-Version` の既定値を現行運用と合わせてよいか