### PR TITLE
fixes #4 S3薄層とキー生成を追加

### DIFF
--- a/internal/acceptance/issue4_feature_test.go
+++ b/internal/acceptance/issue4_feature_test.go
@@ -1,0 +1,153 @@
+package acceptance_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/s3"
+)
+
+func TestIssue4Feature_S3Client(t *testing.T) {
+	t.Run("put stores pdf with HLD key format", func(t *testing.T) {
+		fake := &fakeObjectAPI{}
+		client, err := s3.NewClient("invoice-pdf-stg", fake)
+		if err != nil {
+			t.Fatalf("NewClient returned error: %v", err)
+		}
+
+		key := s3.InvoicePDFKey(s3.InvoicePDFKeyInput{
+			BillingDate:   time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
+			InvoiceNumber: "S-AB202512-01",
+			CustomerName:  "株式会社サンプル / 東京",
+			TotalAmount:   120000,
+		})
+
+		if err := client.PutObject(
+			context.Background(),
+			key,
+			"application/pdf",
+			bytes.NewReader([]byte("%PDF-1.4")),
+		); err != nil {
+			t.Fatalf("PutObject returned error: %v", err)
+		}
+
+		if len(fake.putCalls) != 1 {
+			t.Fatalf("put call count mismatch: got %d", len(fake.putCalls))
+		}
+		got := fake.putCalls[0]
+		if got.Bucket != "invoice-pdf-stg" {
+			t.Fatalf("bucket mismatch: got %q", got.Bucket)
+		}
+		wantKey := "2025/12/2025-12-01_S-AB202512-01_株式会社サンプル_東京_イルカシステム_120000.pdf"
+		if got.Key != wantKey {
+			t.Fatalf("key mismatch: got %q want %q", got.Key, wantKey)
+		}
+		if got.ContentType != "application/pdf" {
+			t.Fatalf("content type mismatch: got %q", got.ContentType)
+		}
+		if string(got.Body) != "%PDF-1.4" {
+			t.Fatalf("body mismatch: got %q", string(got.Body))
+		}
+	})
+
+	t.Run("get loads object with same bucket and key", func(t *testing.T) {
+		fake := &fakeObjectAPI{
+			getOutput: s3.GetObjectOutput{
+				Body:        io.NopCloser(strings.NewReader("%PDF-1.4")),
+				ContentType: "application/pdf",
+			},
+		}
+		client, err := s3.NewClient("invoice-pdf-stg", fake)
+		if err != nil {
+			t.Fatalf("NewClient returned error: %v", err)
+		}
+
+		output, err := client.GetObject(context.Background(), "2025/12/invoice.pdf")
+		if err != nil {
+			t.Fatalf("GetObject returned error: %v", err)
+		}
+		defer output.Body.Close()
+
+		body, err := io.ReadAll(output.Body)
+		if err != nil {
+			t.Fatalf("ReadAll returned error: %v", err)
+		}
+		if len(fake.getCalls) != 1 {
+			t.Fatalf("get call count mismatch: got %d", len(fake.getCalls))
+		}
+		if fake.getCalls[0].Bucket != "invoice-pdf-stg" {
+			t.Fatalf("bucket mismatch: got %q", fake.getCalls[0].Bucket)
+		}
+		if fake.getCalls[0].Key != "2025/12/invoice.pdf" {
+			t.Fatalf("key mismatch: got %q", fake.getCalls[0].Key)
+		}
+		if string(body) != "%PDF-1.4" {
+			t.Fatalf("body mismatch: got %q", string(body))
+		}
+		if output.ContentType != "application/pdf" {
+			t.Fatalf("content type mismatch: got %q", output.ContentType)
+		}
+	})
+
+	t.Run("put returns backend error", func(t *testing.T) {
+		wantErr := errors.New("put failed")
+		client, err := s3.NewClient("invoice-pdf-stg", &fakeObjectAPI{putErr: wantErr})
+		if err != nil {
+			t.Fatalf("NewClient returned error: %v", err)
+		}
+
+		err = client.PutObject(
+			context.Background(),
+			"2025/12/invoice.pdf",
+			"application/pdf",
+			bytes.NewReader([]byte("%PDF-1.4")),
+		)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("PutObject error mismatch: got %v want %v", err, wantErr)
+		}
+	})
+}
+
+type fakeObjectAPI struct {
+	putCalls  []fakePutCall
+	getCalls  []s3.GetObjectInput
+	putErr    error
+	getErr    error
+	getOutput s3.GetObjectOutput
+}
+
+type fakePutCall struct {
+	Bucket      string
+	Key         string
+	ContentType string
+	Body        []byte
+}
+
+func (f *fakeObjectAPI) PutObject(ctx context.Context, input s3.PutObjectInput) error {
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return err
+	}
+
+	f.putCalls = append(f.putCalls, fakePutCall{
+		Bucket:      input.Bucket,
+		Key:         input.Key,
+		ContentType: input.ContentType,
+		Body:        body,
+	})
+
+	return f.putErr
+}
+
+func (f *fakeObjectAPI) GetObject(ctx context.Context, input s3.GetObjectInput) (s3.GetObjectOutput, error) {
+	f.getCalls = append(f.getCalls, input)
+	if f.getErr != nil {
+		return s3.GetObjectOutput{}, f.getErr
+	}
+	return f.getOutput, nil
+}

--- a/internal/s3/client.go
+++ b/internal/s3/client.go
@@ -1,0 +1,68 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+)
+
+var ErrBucketRequired = errors.New("s3 bucket is required")
+
+type ObjectAPI interface {
+	PutObject(ctx context.Context, input PutObjectInput) error
+	GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error)
+}
+
+type PutObjectInput struct {
+	Bucket      string
+	Key         string
+	ContentType string
+	Body        io.Reader
+}
+
+type GetObjectInput struct {
+	Bucket string
+	Key    string
+}
+
+type GetObjectOutput struct {
+	Body        io.ReadCloser
+	ContentType string
+}
+
+type Client struct {
+	bucket string
+	api    ObjectAPI
+}
+
+func NewClient(bucket string, api ObjectAPI) (*Client, error) {
+	trimmedBucket := strings.TrimSpace(bucket)
+	if trimmedBucket == "" {
+		return nil, ErrBucketRequired
+	}
+	if api == nil {
+		return nil, errors.New("s3 object api is required")
+	}
+
+	return &Client{
+		bucket: trimmedBucket,
+		api:    api,
+	}, nil
+}
+
+func (c *Client) PutObject(ctx context.Context, key, contentType string, body io.Reader) error {
+	return c.api.PutObject(ctx, PutObjectInput{
+		Bucket:      c.bucket,
+		Key:         key,
+		ContentType: contentType,
+		Body:        body,
+	})
+}
+
+func (c *Client) GetObject(ctx context.Context, key string) (GetObjectOutput, error) {
+	return c.api.GetObject(ctx, GetObjectInput{
+		Bucket: c.bucket,
+		Key:    key,
+	})
+}

--- a/internal/s3/client_test.go
+++ b/internal/s3/client_test.go
@@ -1,0 +1,152 @@
+package s3
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestNewClientRequiresBucket(t *testing.T) {
+	_, err := NewClient("", noopObjectAPI{})
+	if err == nil {
+		t.Fatal("NewClient error = nil")
+	}
+}
+
+func TestClientPutObjectPassesBucketAndKey(t *testing.T) {
+	fake := &captureObjectAPI{}
+	client, err := NewClient("invoice-pdf-stg", fake)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	err = client.PutObject(
+		context.Background(),
+		"2025/12/invoice.pdf",
+		"application/pdf",
+		bytes.NewReader([]byte("pdf-data")),
+	)
+	if err != nil {
+		t.Fatalf("PutObject returned error: %v", err)
+	}
+
+	if fake.lastPut.Bucket != "invoice-pdf-stg" {
+		t.Fatalf("bucket mismatch: got %q", fake.lastPut.Bucket)
+	}
+	if fake.lastPut.Key != "2025/12/invoice.pdf" {
+		t.Fatalf("key mismatch: got %q", fake.lastPut.Key)
+	}
+	if fake.lastPut.ContentType != "application/pdf" {
+		t.Fatalf("content type mismatch: got %q", fake.lastPut.ContentType)
+	}
+	if string(fake.lastPut.Body) != "pdf-data" {
+		t.Fatalf("body mismatch: got %q", string(fake.lastPut.Body))
+	}
+}
+
+func TestClientGetObjectPassesBucketAndReturnsOutput(t *testing.T) {
+	fake := &captureObjectAPI{
+		getOutput: GetObjectOutput{
+			Body:        io.NopCloser(strings.NewReader("pdf-data")),
+			ContentType: "application/pdf",
+		},
+	}
+	client, err := NewClient("invoice-pdf-stg", fake)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	output, err := client.GetObject(context.Background(), "2025/12/invoice.pdf")
+	if err != nil {
+		t.Fatalf("GetObject returned error: %v", err)
+	}
+	defer output.Body.Close()
+
+	if fake.lastGet.Bucket != "invoice-pdf-stg" {
+		t.Fatalf("bucket mismatch: got %q", fake.lastGet.Bucket)
+	}
+	if fake.lastGet.Key != "2025/12/invoice.pdf" {
+		t.Fatalf("key mismatch: got %q", fake.lastGet.Key)
+	}
+
+	body, err := io.ReadAll(output.Body)
+	if err != nil {
+		t.Fatalf("ReadAll returned error: %v", err)
+	}
+	if string(body) != "pdf-data" {
+		t.Fatalf("body mismatch: got %q", string(body))
+	}
+}
+
+func TestClientPropagatesBackendErrors(t *testing.T) {
+	wantErr := errors.New("backend error")
+	client, err := NewClient("invoice-pdf-stg", &captureObjectAPI{
+		putErr: wantErr,
+		getErr: wantErr,
+	})
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	err = client.PutObject(context.Background(), "invoice.pdf", "application/pdf", bytes.NewReader(nil))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("PutObject error mismatch: got %v want %v", err, wantErr)
+	}
+
+	_, err = client.GetObject(context.Background(), "invoice.pdf")
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("GetObject error mismatch: got %v want %v", err, wantErr)
+	}
+}
+
+type noopObjectAPI struct{}
+
+func (noopObjectAPI) PutObject(ctx context.Context, input PutObjectInput) error {
+	return nil
+}
+
+func (noopObjectAPI) GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error) {
+	return GetObjectOutput{}, nil
+}
+
+type captureObjectAPI struct {
+	lastPut   capturePutInput
+	lastGet   GetObjectInput
+	putErr    error
+	getErr    error
+	getOutput GetObjectOutput
+}
+
+type capturePutInput struct {
+	Bucket      string
+	Key         string
+	ContentType string
+	Body        []byte
+}
+
+func (c *captureObjectAPI) PutObject(ctx context.Context, input PutObjectInput) error {
+	body, err := io.ReadAll(input.Body)
+	if err != nil {
+		return err
+	}
+
+	c.lastPut = capturePutInput{
+		Bucket:      input.Bucket,
+		Key:         input.Key,
+		ContentType: input.ContentType,
+		Body:        body,
+	}
+
+	return c.putErr
+}
+
+func (c *captureObjectAPI) GetObject(ctx context.Context, input GetObjectInput) (GetObjectOutput, error) {
+	c.lastGet = input
+	if c.getErr != nil {
+		return GetObjectOutput{}, c.getErr
+	}
+	return c.getOutput, nil
+}

--- a/internal/s3/key.go
+++ b/internal/s3/key.go
@@ -1,0 +1,71 @@
+package s3
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const issuerName = "イルカシステム"
+
+type InvoicePDFKeyInput struct {
+	BillingDate   time.Time
+	InvoiceNumber string
+	CustomerName  string
+	TotalAmount   float64
+}
+
+func InvoicePDFKey(input InvoicePDFKeyInput) string {
+	billingDate := input.BillingDate.Format("2006-01-02")
+	yearMonth := input.BillingDate.Format("2006/01")
+
+	return fmt.Sprintf(
+		"%s/%s_%s_%s_%s_%s.pdf",
+		yearMonth,
+		billingDate,
+		input.InvoiceNumber,
+		NormalizeFileNameSegment(input.CustomerName),
+		issuerName,
+		formatAmount(input.TotalAmount),
+	)
+}
+
+func NormalizeFileNameSegment(value string) string {
+	var builder strings.Builder
+	lastUnderscore := false
+
+	for _, r := range strings.TrimSpace(value) {
+		if isFileNameSafeRune(r) {
+			builder.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			builder.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+
+	return strings.Trim(builder.String(), "_")
+}
+
+func isFileNameSafeRune(r rune) bool {
+	switch {
+	case unicode.IsLetter(r), unicode.IsDigit(r):
+		return true
+	case r == '-', r == '_':
+		return true
+	default:
+		return false
+	}
+}
+
+func formatAmount(value float64) string {
+	if value == float64(int64(value)) {
+		return strconv.FormatInt(int64(value), 10)
+	}
+
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}

--- a/internal/s3/key_test.go
+++ b/internal/s3/key_test.go
@@ -1,0 +1,28 @@
+package s3
+
+import (
+	"testing"
+	"time"
+)
+
+func TestInvoicePDFKey(t *testing.T) {
+	got := InvoicePDFKey(InvoicePDFKeyInput{
+		BillingDate:   time.Date(2025, 2, 3, 0, 0, 0, 0, time.UTC),
+		InvoiceNumber: "S-AB202502-01",
+		CustomerName:  "株式会社サンプル / 東京",
+		TotalAmount:   120000,
+	})
+
+	want := "2025/02/2025-02-03_S-AB202502-01_株式会社サンプル_東京_イルカシステム_120000.pdf"
+	if got != want {
+		t.Fatalf("InvoicePDFKey mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeFileNameSegment(t *testing.T) {
+	got := NormalizeFileNameSegment(" ACME / 東京(本社) ")
+	want := "ACME_東京_本社"
+	if got != want {
+		t.Fatalf("NormalizeFileNameSegment mismatch: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
fixes #4

## Summary
1. S3 の PutObject/GetObject を bucket 固定の薄い client として追加しました。
2. 請求書 PDF の S3 キー生成ヘルパと顧客名のファイル名正規化を追加しました。
3. issue #4 の受け入れ条件を feature test と unit test で固定しました。

## Changes
### 58d2c27 fixes #4 S3薄層とキー生成を追加
* S3 PutObject/GetObject を薄く中継する client を追加
* 請求書 PDF 向けの S3 キー生成とファイル名正規化を追加
* issue #4 の feature test と unit test を追加

## Comment
- `NormalizeFileNameSegment` の置換方針が HLD 4.5 の期待とずれていないかを確認してください。
- S3 client を今後 AWS SDK 実装へ差し替える際も、現在の引数境界で十分かを確認してください。
