### PR TITLE
fixes #5 SendGrid薄層を追加

### DIFF
--- a/ai/tasks/todo.md
+++ b/ai/tasks/todo.md
@@ -180,3 +180,36 @@
 - 取得自体を一律禁止するのではなく、必要最小限の参照は許容しつつ、標準出力・ログ・応答への生値出力を禁止する方針に整理した
 - `gh auth status` を唯一の認証状態確認手段として明示し、`gh auth token`、token/cookie/header の表示、`env` 系や `git credential` 系の secrets 可視化利用を禁止した
 - 認証失敗時は secrets を出さずに停止すること、マスク不能な場合はコマンド自体を実行しないことを明記した
+
+## 2026-04-08 issue #5 実装計画
+
+- [x] `AGENTS.md` `docs/ARCHITECTURES.md` `docs/HLD.md` `ai/tasks/*.md` と issue #5 を確認する
+- [x] `feature/dev#5` の専用 worktree 上で進める前提を確認する
+- [x] issue #5 の feature-level integration test を追加し、受け入れ条件を固定する
+- [x] `sendgrid-request` subtask で `/mail/send` の request 組み立てと PDF 添付 BASE64 化を実装する
+- [x] `recipient-validation` subtask で宛先バリデーションを追加する
+- [x] `error-classification` subtask で 4xx / 5xx / 429 の異常応答種別化を追加する
+- [ ] issue 全体テスト、最終 review、最終 commit、PR 作成を行う
+
+### Subtasks
+
+- [x] `sendgrid-request` - `POST /mail/send` の URL、ヘッダ、JSON payload を HLD 5.2 に合わせて固定する
+- [x] `recipient-validation` - `billing_email` の空値と不正形式を送信前に弾く
+- [x] `error-classification` - SendGrid の異常応答を呼び出し側で判定しやすいエラー型へ分類する
+
+### Acceptance
+
+- [x] `SENDGRID_BASE_URL + /mail/send` に `POST` し、`Authorization` と `Content-Type: application/json` を付ける
+- [x] 件名、本文、送信元、宛先、PDF 添付 BASE64 が request body に含まれる
+- [x] `billing_email` が空または不正な場合は HTTP 送信前にバリデーションエラーを返す
+- [x] 429 / 4xx / 5xx の応答を別種のエラーとして返し、再試行前提の曖昧な失敗にしない
+
+### Review
+
+- issue #5 のスコープは SendGrid 薄層の request 組み立て、宛先バリデーション、異常応答種別化に限定する
+- HLD 5.2.2 の本文形式は text / HTML のいずれか許容のため、最小差分として `text/plain` を採用する
+- Invoices 抽出、S3 取得、`email_status` 更新は issue #5 の外側に置き、この issue では固定しない
+- `internal/sendgrid.Client` を追加し、`/mail/send` への JSON request 組み立て、Bearer 認証ヘッダ付与、PDF 添付の BASE64 化を実装した
+- `ValidationError` と `RateLimitError` / `ClientError` / `ServerError` を追加し、宛先検証と SendGrid 応答の種別化を呼び出し側で判定できる形にした
+- `internal/acceptance/issue5_feature_test.go` と `internal/sendgrid/client_test.go` で正常系、宛先エラー、4xx / 5xx / 429 を固定した
+- `GOCACHE=/tmp/notion-issue5-go-build GOMODCACHE=/tmp/notion-issue5-gomod go test ./internal/acceptance ./internal/sendgrid` は成功した

--- a/internal/acceptance/issue5_feature_test.go
+++ b/internal/acceptance/issue5_feature_test.go
@@ -1,0 +1,264 @@
+package acceptance_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/irukasano/notion-invoice-with-lambda/internal/sendgrid"
+)
+
+func TestIssue5Feature_SendGridClient(t *testing.T) {
+	t.Run("mail send request includes headers body and base64 attachment", func(t *testing.T) {
+		var got sendGridRequestCapture
+		client := newTestSendGridClient(t, sendGridDoerFunc(func(r *http.Request) (*http.Response, error) {
+			got = captureSendGridRequest(t, r)
+			return sendGridJSONResponse(http.StatusAccepted, `{"message":"accepted"}`), nil
+		}))
+
+		err := client.SendMail(context.Background(), sendgrid.SendMailInput{
+			ToEmail:   "billing@example.com",
+			ToName:    "経理担当",
+			Subject:   "[請求書] 株式会社サンプル様 2025-12分 ご請求のご案内",
+			PlainText: "2025-12分の請求書をお送りします。",
+			Attachments: []sendgrid.Attachment{
+				{
+					Filename:    "invoice.pdf",
+					ContentType: "application/pdf",
+					Content:     []byte("%PDF-1.4"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("SendMail returned error: %v", err)
+		}
+
+		if got.Method != http.MethodPost {
+			t.Fatalf("method mismatch: got %q", got.Method)
+		}
+		if got.Path != "/v3/mail/send" {
+			t.Fatalf("path mismatch: got %q", got.Path)
+		}
+		if got.Authorization != "Bearer sendgrid-secret" {
+			t.Fatalf("authorization mismatch: got %q", got.Authorization)
+		}
+		if got.ContentType != "application/json" {
+			t.Fatalf("content type mismatch: got %q", got.ContentType)
+		}
+
+		from, ok := got.Body["from"].(map[string]any)
+		if !ok {
+			t.Fatalf("from type mismatch: got %#v", got.Body["from"])
+		}
+		if from["email"] != "noreply@example.com" {
+			t.Fatalf("from email mismatch: got %#v", from["email"])
+		}
+		if from["name"] != "イルカシステム" {
+			t.Fatalf("from name mismatch: got %#v", from["name"])
+		}
+
+		personalizations, ok := got.Body["personalizations"].([]any)
+		if !ok || len(personalizations) != 1 {
+			t.Fatalf("personalizations mismatch: got %#v", got.Body["personalizations"])
+		}
+		personalization, ok := personalizations[0].(map[string]any)
+		if !ok {
+			t.Fatalf("personalization type mismatch: got %#v", personalizations[0])
+		}
+		toList, ok := personalization["to"].([]any)
+		if !ok || len(toList) != 1 {
+			t.Fatalf("to list mismatch: got %#v", personalization["to"])
+		}
+		to, ok := toList[0].(map[string]any)
+		if !ok {
+			t.Fatalf("to type mismatch: got %#v", toList[0])
+		}
+		if to["email"] != "billing@example.com" {
+			t.Fatalf("to email mismatch: got %#v", to["email"])
+		}
+		if to["name"] != "経理担当" {
+			t.Fatalf("to name mismatch: got %#v", to["name"])
+		}
+
+		if got.Body["subject"] != "[請求書] 株式会社サンプル様 2025-12分 ご請求のご案内" {
+			t.Fatalf("subject mismatch: got %#v", got.Body["subject"])
+		}
+
+		contentList, ok := got.Body["content"].([]any)
+		if !ok || len(contentList) != 1 {
+			t.Fatalf("content mismatch: got %#v", got.Body["content"])
+		}
+		content, ok := contentList[0].(map[string]any)
+		if !ok {
+			t.Fatalf("content type mismatch: got %#v", contentList[0])
+		}
+		if content["type"] != "text/plain" {
+			t.Fatalf("content type mismatch: got %#v", content["type"])
+		}
+		if content["value"] != "2025-12分の請求書をお送りします。" {
+			t.Fatalf("content value mismatch: got %#v", content["value"])
+		}
+
+		attachments, ok := got.Body["attachments"].([]any)
+		if !ok || len(attachments) != 1 {
+			t.Fatalf("attachments mismatch: got %#v", got.Body["attachments"])
+		}
+		attachment, ok := attachments[0].(map[string]any)
+		if !ok {
+			t.Fatalf("attachment type mismatch: got %#v", attachments[0])
+		}
+		if attachment["filename"] != "invoice.pdf" {
+			t.Fatalf("filename mismatch: got %#v", attachment["filename"])
+		}
+		if attachment["type"] != "application/pdf" {
+			t.Fatalf("attachment type mismatch: got %#v", attachment["type"])
+		}
+		if attachment["disposition"] != "attachment" {
+			t.Fatalf("disposition mismatch: got %#v", attachment["disposition"])
+		}
+		if attachment["content"] != "JVBERi0xLjQ=" {
+			t.Fatalf("attachment content mismatch: got %#v", attachment["content"])
+		}
+	})
+
+	t.Run("recipient validation fails before http request", func(t *testing.T) {
+		requestCount := 0
+		client := newTestSendGridClient(t, sendGridDoerFunc(func(r *http.Request) (*http.Response, error) {
+			requestCount++
+			return sendGridJSONResponse(http.StatusAccepted, `{"message":"accepted"}`), nil
+		}))
+
+		err := client.SendMail(context.Background(), sendgrid.SendMailInput{
+			ToEmail:   "invalid-address",
+			Subject:   "subject",
+			PlainText: "body",
+		})
+		if err == nil {
+			t.Fatal("SendMail returned nil error")
+		}
+
+		var validationErr *sendgrid.ValidationError
+		if !errors.As(err, &validationErr) {
+			t.Fatalf("expected ValidationError, got %T", err)
+		}
+		if validationErr.Field != "to_email" {
+			t.Fatalf("field mismatch: got %q", validationErr.Field)
+		}
+		if requestCount != 0 {
+			t.Fatalf("unexpected request count: got %d", requestCount)
+		}
+	})
+
+	t.Run("error responses are classified", func(t *testing.T) {
+		t.Run("429", func(t *testing.T) {
+			client := newTestSendGridClient(t, sendGridDoerFunc(func(r *http.Request) (*http.Response, error) {
+				return sendGridJSONResponse(http.StatusTooManyRequests, `{"errors":[{"message":"rate limit"}]}`), nil
+			}))
+
+			err := client.SendMail(context.Background(), sendgrid.SendMailInput{
+				ToEmail:   "billing@example.com",
+				Subject:   "subject",
+				PlainText: "body",
+			})
+			if err == nil {
+				t.Fatal("SendMail returned nil error")
+			}
+
+			var rateLimitErr *sendgrid.RateLimitError
+			if !errors.As(err, &rateLimitErr) {
+				t.Fatalf("expected RateLimitError, got %T", err)
+			}
+		})
+
+		t.Run("5xx", func(t *testing.T) {
+			client := newTestSendGridClient(t, sendGridDoerFunc(func(r *http.Request) (*http.Response, error) {
+				return sendGridJSONResponse(http.StatusBadGateway, `{"errors":[{"message":"bad gateway"}]}`), nil
+			}))
+
+			err := client.SendMail(context.Background(), sendgrid.SendMailInput{
+				ToEmail:   "billing@example.com",
+				Subject:   "subject",
+				PlainText: "body",
+			})
+			if err == nil {
+				t.Fatal("SendMail returned nil error")
+			}
+
+			var serverErr *sendgrid.ServerError
+			if !errors.As(err, &serverErr) {
+				t.Fatalf("expected ServerError, got %T", err)
+			}
+		})
+	})
+}
+
+type sendGridRequestCapture struct {
+	Method        string
+	Path          string
+	Authorization string
+	ContentType   string
+	Body          map[string]any
+}
+
+func newTestSendGridClient(t *testing.T, httpClient sendgrid.HTTPDoer) *sendgrid.Client {
+	t.Helper()
+
+	client, err := sendgrid.NewClient(sendgrid.ClientConfig{
+		BaseURL:   "https://api.sendgrid.test/v3",
+		APIKey:    "sendgrid-secret",
+		FromEmail: "noreply@example.com",
+		FromName:  "イルカシステム",
+	}, httpClient)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	return client
+}
+
+func captureSendGridRequest(t *testing.T, r *http.Request) sendGridRequestCapture {
+	t.Helper()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("io.ReadAll returned error: %v", err)
+	}
+	defer r.Body.Close()
+
+	var payload map[string]any
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("json.Unmarshal returned error: %v", err)
+		}
+	} else {
+		payload = map[string]any{}
+	}
+
+	return sendGridRequestCapture{
+		Method:        r.Method,
+		Path:          r.URL.Path,
+		Authorization: r.Header.Get("Authorization"),
+		ContentType:   r.Header.Get("Content-Type"),
+		Body:          payload,
+	}
+}
+
+type sendGridDoerFunc func(*http.Request) (*http.Response, error)
+
+func (f sendGridDoerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func sendGridJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/sendgrid/client.go
+++ b/internal/sendgrid/client.go
@@ -1,0 +1,204 @@
+package sendgrid
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/mail"
+	"strings"
+)
+
+const defaultBaseURL = "https://api.sendgrid.com/v3"
+
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type ClientConfig struct {
+	BaseURL   string
+	APIKey    string
+	FromEmail string
+	FromName  string
+}
+
+type Attachment struct {
+	Filename    string
+	ContentType string
+	Content     []byte
+}
+
+type SendMailInput struct {
+	ToEmail     string
+	ToName      string
+	Subject     string
+	PlainText   string
+	Attachments []Attachment
+}
+
+type Client struct {
+	baseURL    string
+	apiKey     string
+	fromEmail  string
+	fromName   string
+	httpClient HTTPDoer
+}
+
+func NewClient(cfg ClientConfig, httpClient HTTPDoer) (*Client, error) {
+	baseURL := strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/")
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	if strings.TrimSpace(cfg.APIKey) == "" {
+		return nil, errors.New("sendgrid api key is required")
+	}
+	if _, err := parseEmail("from_email", cfg.FromEmail); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(cfg.FromName) == "" {
+		return nil, errors.New("sendgrid from name is required")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	return &Client{
+		baseURL:    baseURL,
+		apiKey:     strings.TrimSpace(cfg.APIKey),
+		fromEmail:  strings.TrimSpace(cfg.FromEmail),
+		fromName:   strings.TrimSpace(cfg.FromName),
+		httpClient: httpClient,
+	}, nil
+}
+
+func (c *Client) SendMail(ctx context.Context, input SendMailInput) error {
+	toEmail, err := parseEmail("to_email", input.ToEmail)
+	if err != nil {
+		return err
+	}
+
+	payload := mailSendPayload{
+		From: emailAddress{
+			Email: c.fromEmail,
+			Name:  c.fromName,
+		},
+		Personalizations: []personalization{{
+			To: []emailAddress{{
+				Email: toEmail,
+				Name:  strings.TrimSpace(input.ToName),
+			}},
+		}},
+		Subject: strings.TrimSpace(input.Subject),
+		Content: []content{{
+			Type:  "text/plain",
+			Value: input.PlainText,
+		}},
+		Attachments: make([]attachment, 0, len(input.Attachments)),
+	}
+
+	for _, item := range input.Attachments {
+		payload.Attachments = append(payload.Attachments, attachment{
+			Content:     base64.StdEncoding.EncodeToString(item.Content),
+			Type:        strings.TrimSpace(item.ContentType),
+			Filename:    strings.TrimSpace(item.Filename),
+			Disposition: "attachment",
+		})
+	}
+
+	req, err := c.newJSONRequest(ctx, http.MethodPost, "/mail/send", payload)
+	if err != nil {
+		return err
+	}
+
+	return c.do(req)
+}
+
+func (c *Client) newJSONRequest(ctx context.Context, method, path string, payload any) (*http.Request, error) {
+	var body io.Reader
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		body = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	return req, nil
+}
+
+func (c *Client) do(req *http.Request) error {
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return classifyHTTPError(req, resp.StatusCode, body)
+	}
+
+	return nil
+}
+
+func parseEmail(field, value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", &ValidationError{
+			Field:   field,
+			Message: "is required",
+		}
+	}
+	addr, err := mail.ParseAddress(trimmed)
+	if err != nil {
+		return "", &ValidationError{
+			Field:   field,
+			Message: "must be a valid email address",
+		}
+	}
+	return addr.Address, nil
+}
+
+type mailSendPayload struct {
+	Personalizations []personalization `json:"personalizations"`
+	From             emailAddress      `json:"from"`
+	Subject          string            `json:"subject"`
+	Content          []content         `json:"content"`
+	Attachments      []attachment      `json:"attachments,omitempty"`
+}
+
+type personalization struct {
+	To []emailAddress `json:"to"`
+}
+
+type emailAddress struct {
+	Email string `json:"email"`
+	Name  string `json:"name,omitempty"`
+}
+
+type content struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
+type attachment struct {
+	Content     string `json:"content"`
+	Type        string `json:"type,omitempty"`
+	Filename    string `json:"filename,omitempty"`
+	Disposition string `json:"disposition,omitempty"`
+}

--- a/internal/sendgrid/client_test.go
+++ b/internal/sendgrid/client_test.go
@@ -1,0 +1,118 @@
+package sendgrid
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewClientRequiresMandatoryFields(t *testing.T) {
+	t.Run("api key is required", func(t *testing.T) {
+		_, err := NewClient(ClientConfig{
+			BaseURL:   "https://api.sendgrid.test/v3",
+			FromEmail: "noreply@example.com",
+			FromName:  "イルカシステム",
+		}, doerFunc(nil))
+		if err == nil {
+			t.Fatal("NewClient error = nil")
+		}
+	})
+
+	t.Run("from email must be valid", func(t *testing.T) {
+		_, err := NewClient(ClientConfig{
+			BaseURL:   "https://api.sendgrid.test/v3",
+			APIKey:    "secret",
+			FromEmail: "invalid",
+			FromName:  "イルカシステム",
+		}, doerFunc(nil))
+		if err == nil {
+			t.Fatal("NewClient error = nil")
+		}
+	})
+}
+
+func TestSendMailReturnsValidationErrorBeforeHTTP(t *testing.T) {
+	requestCount := 0
+	client := mustNewClient(t, doerFunc(func(r *http.Request) (*http.Response, error) {
+		requestCount++
+		return jsonResponse(http.StatusAccepted, `{"message":"accepted"}`), nil
+	}))
+
+	err := client.SendMail(context.Background(), SendMailInput{
+		ToEmail:   "",
+		Subject:   "subject",
+		PlainText: "body",
+	})
+	if err == nil {
+		t.Fatal("SendMail error = nil")
+	}
+
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %T", err)
+	}
+	if validationErr.Field != "to_email" {
+		t.Fatalf("field mismatch: got %q", validationErr.Field)
+	}
+	if requestCount != 0 {
+		t.Fatalf("unexpected request count: got %d", requestCount)
+	}
+}
+
+func TestSendMailClassifiesClientError(t *testing.T) {
+	client := mustNewClient(t, doerFunc(func(r *http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusBadRequest, `{"errors":[{"message":"bad request"}]}`), nil
+	}))
+
+	err := client.SendMail(context.Background(), SendMailInput{
+		ToEmail:   "billing@example.com",
+		Subject:   "subject",
+		PlainText: "body",
+	})
+	if err == nil {
+		t.Fatal("SendMail error = nil")
+	}
+
+	var clientErr *ClientError
+	if !errors.As(err, &clientErr) {
+		t.Fatalf("expected ClientError, got %T", err)
+	}
+	if clientErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status code mismatch: got %d", clientErr.StatusCode)
+	}
+}
+
+func mustNewClient(t *testing.T, httpClient HTTPDoer) *Client {
+	t.Helper()
+
+	client, err := NewClient(ClientConfig{
+		BaseURL:   "https://api.sendgrid.test/v3",
+		APIKey:    "secret",
+		FromEmail: "noreply@example.com",
+		FromName:  "イルカシステム",
+	}, httpClient)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	return client
+}
+
+type doerFunc func(*http.Request) (*http.Response, error)
+
+func (f doerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func jsonResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Body: io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/sendgrid/errors.go
+++ b/internal/sendgrid/errors.go
@@ -1,0 +1,63 @@
+package sendgrid
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("sendgrid validation failed for %s: %s", e.Field, e.Message)
+}
+
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf(
+		"sendgrid api %s %s returned %d: %s",
+		e.Method,
+		e.Path,
+		e.StatusCode,
+		e.Body,
+	)
+}
+
+type RateLimitError struct {
+	HTTPError
+}
+
+type ServerError struct {
+	HTTPError
+}
+
+type ClientError struct {
+	HTTPError
+}
+
+func classifyHTTPError(req *http.Request, statusCode int, body []byte) error {
+	httpErr := HTTPError{
+		Method:     req.Method,
+		Path:       req.URL.Path,
+		StatusCode: statusCode,
+		Body:       strings.TrimSpace(string(body)),
+	}
+
+	switch {
+	case statusCode == http.StatusTooManyRequests:
+		return &RateLimitError{HTTPError: httpErr}
+	case statusCode >= http.StatusInternalServerError:
+		return &ServerError{HTTPError: httpErr}
+	default:
+		return &ClientError{HTTPError: httpErr}
+	}
+}


### PR DESCRIPTION
fixes #5

## Summary
1. SendGrid `/mail/send` に向けた薄い client を追加し、Bearer 認証と JSON payload 組み立てを実装しました。
2. 宛先 email の事前検証と `429` / `4xx` / `5xx` のエラー分類を追加し、呼び出し側で判定しやすくしました。
3. acceptance / unit test で PDF 添付の BASE64 化、宛先エラー、異常応答の振る舞いを固定しました。

## Changes
### 62cb325 fixes #5 SendGrid薄層を追加
* SendGrid client と送信 payload を追加
* 宛先検証と HTTP エラー分類を追加
* acceptance と unit test で送信条件を固定

## Comment
- 本文形式は HLD 5.2.2 の許容範囲内で最小差分の `text/plain` を採用しています。
- issue #5 のスコープ外である Invoices 抽出、S3 取得、`email_status` 更新はこの PR に含めていません。